### PR TITLE
Make sidebar wider for pwamp

### DIFF
--- a/pwamp/manifest.json
+++ b/pwamp/manifest.json
@@ -11,7 +11,9 @@
   "display_override": [
     "window-controls-overlay"
   ],
-  "edge_side_panel": {},
+  "edge_side_panel": {
+    "preferred_width": 496
+  },
   "icons": [
     {
       "src": "./favicon-48.png",


### PR DESCRIPTION
Looking to record a demo of this app's media control capabilities and would like to make the preferred width more noticeable, as part of being a sidebar pwa.