### PR TITLE
[Wami] Remove title logic from server worker

### DIFF
--- a/wami/app.js
+++ b/wami/app.js
@@ -481,7 +481,7 @@ async function processShareTargetData() {
 // Determines the flow configuration (title and steps) based on shared data
 function determineFlowConfiguration(shareData) {
   // Default flow title and steps
-  let flowTitle = shareData.title || 'Shared Images Flow';
+  let flowTitle = 'Shared Images Flow';
   let flowSteps = [
     {
       type: 'resize-width-if-larger',

--- a/wami/sw.js
+++ b/wami/sw.js
@@ -109,7 +109,6 @@ self.addEventListener('fetch', event => {
           
           // Extract data
           const data = {
-            title: formData.get('title') || '',
             text: formData.get('text') || '',
             url: formData.get('url') || ''
           };
@@ -126,7 +125,6 @@ self.addEventListener('fetch', event => {
             
             // Create an object with the share data including file names
             const shareData = {
-              title: data.title,
               text: data.text,
               url: data.url,
               timestamp: Date.now(),


### PR DESCRIPTION
### Summary
AI action scenario doesn't use title attribute, title will be always null in the case. This PR aims to remove title logic from service worker handler to reduce PWA developers' confusion when to onboard PWA AI action.

### Validation
Have verified the change locally
![image](https://github.com/user-attachments/assets/8cb446cb-d549-4ccc-8ab4-df8ef256eb1c)
