### PR TITLE
[Wami] Fix protocol_hanlders definition

### DIFF
--- a/wami/manifest.json
+++ b/wami/manifest.json
@@ -32,7 +32,7 @@
   "protocol_handlers": [
     {
       "protocol": "web+wami",
-      "url": "./?url=%s"
+      "url": "/?url=%s"
     }
   ],
   "share_target": {

--- a/wami/manifest.json
+++ b/wami/manifest.json
@@ -32,7 +32,7 @@
   "protocol_handlers": [
     {
       "protocol": "web+wami",
-      "url": "/?url=%s"
+      "url": "/Demos/wami/?url=%s"
     }
   ],
   "share_target": {


### PR DESCRIPTION
Standard [protocol_hanlders.url](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/protocol_handlers#url) should all be relative URLs that are within the scope of the app. This PR aims to fix the issue.

With `.`, manifest check will fail in pwabuilder.com
![image](https://github.com/user-attachments/assets/53ea2b17-5f4e-41fe-bea3-951fa878007f)

After replacing `.`, the error will be fixed. 
![image](https://github.com/user-attachments/assets/29c490dc-4c57-4ae3-9b70-f1e9079785c2)