### PR TITLE
Add pwa-web-install-api directory and fixup pwa-store app

### DIFF
--- a/pwa-pwastore/app.js
+++ b/pwa-pwastore/app.js
@@ -5,8 +5,8 @@ const bubbleBtn = document.getElementById("installBubble");
 const installBtn = document.getElementById("btnInstallStore");
 
 pwinterBtn.addEventListener('click', () => {
-  navigator.install('https://diek.us/pwinter/index.html?randomize=true',
-                    'https://diek.us/pwinter/')
+  navigator.install('https://diek.us/pwinter/',
+                    'https://diek.us/pwinter/index.html?randomize=true')
 });
 
 pwampBtn.addEventListener('click', () => {
@@ -15,8 +15,8 @@ pwampBtn.addEventListener('click', () => {
 });
 
 bubbleBtn.addEventListener('click', () => {
-  navigator.install('https://diek.us/bubble/index.html',
-                    'https://diek.us/bubble/')
+  navigator.install('https://diek.us/bubble/',
+                    'https://diek.us/bubble/index.html')
 });
 
 installBtn.addEventListener('click', () => {

--- a/pwa-web-install-api/README.md
+++ b/pwa-web-install-api/README.md
@@ -1,0 +1,19 @@
+# web install API - `navigator.install`
+
+This directory contains demos that showcase the use of [navigator.install](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/WebInstall/explainer.md), an API under development by the Microsoft Edge team to allow web contents to declaratively install other web apps.
+
+## Demos
+
+* [PWA Store](https://microsoftedge.github.io/Demos/pwa-pwastore)
+* [Web Install Sample](https://kbhlee2121.github.io/pwa/web-install/index.html)
+
+## Try the feature and share feedback
+
+To try the feature, follow these steps:
+
+1. Use a Chromium-based browser, such as Microsoft Edge or Chrome, and make sure the version is at least 139.0.3402.0 in Edge, or 139.0.7258.0 in Chrome.
+1. In the browser, open a new tab and go to `about:flags`.
+1. Search for "web-app-installation-api" in the search box.
+1. Set the **Web App Installation API** flag to **Enabled**, and then restart the browser.
+
+To share feedback, please [open an issue on the MSEdgeExplainers repository](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?template=css-gap-decorations.md).


### PR DESCRIPTION
Adds a `pwa-web-install-api` directory with a README to be used in our chrome status page for dev trials instructions. The README currently links an external demo site and /pwa-store app. Also fixup pwa-store so the parameters to the API call are in the correct order (install_url, manifest_id). Eventually we may also migrate the external demo site to this web-install-api directory as well.