### PR TITLE
[WebInstallAPI] Fix link to open github issue

### DIFF
--- a/pwa-web-install-api/README.md
+++ b/pwa-web-install-api/README.md
@@ -16,4 +16,4 @@ To try the feature, follow these steps:
 1. Search for "web-app-installation-api" in the search box.
 1. Set the **Web App Installation API** flag to **Enabled**, and then restart the browser.
 
-To share feedback, please [open an issue on the MSEdgeExplainers repository](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?template=css-gap-decorations.md).
+To share feedback, please [open an issue on the MSEdgeExplainers repository](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?template=web-install-api.md).


### PR DESCRIPTION
Fix the README link that opens a new github issue so it correctly categorizes it as web install.