### PR TITLE
[highlightsFromPoint] Add highlight types to spelling/grammar highlights

### DIFF
--- a/custom-highlight-api/highlightsFromPoint/script.js
+++ b/custom-highlight-api/highlightsFromPoint/script.js
@@ -65,7 +65,10 @@ function createHighlightsForWords(textNodes, words, highlightName) {
 
   // If we found any words/phrases, create and register the highlight with the respective ranges
   if (ranges.length > 0) {
-    const highlight = new Highlight(...ranges);
+    let highlight = new Highlight(...ranges);
+    if (["spelling-error", "grammar-error"].includes(highlightName)) {
+      highlight.type = highlightName;
+    }
     CSS.highlights.set(highlightName, highlight);
   }
 }


### PR DESCRIPTION
Set `highlight.type` for spelling-error and grammar-error highlights so they can be announced by accessibility tools and to demonstrate also good practices when dealing with custom highlights.