### PR TITLE
Update focusgroup examples to follow the latest version of the API.

### DIFF
--- a/focusgroup/README.md
+++ b/focusgroup/README.md
@@ -6,7 +6,7 @@ Interactive demos for the HTML `focusgroup` attribute, which lets you add arrow-
 
 ## Demos
 
-> **Note:** The `focusgroup` behavior token maps a minimum ARIA role to generic containers (e.g., a plain `<div>`) and can infer child roles (e.g., `tab` on `<button>` inside a `tablist`). When you set an explicit `role` or use a non-generic element, the mapping is skipped. These demos set roles explicitly for clarity.
+> **Note:** The `focusgroup` behavior token maps a minimum ARIA role to generic containers (e.g., a plain `<div>`) and can infer child roles (e.g., `tab` on `<button>` inside a `tablist`). These demos rely on that automatic mapping. Explicit `role` attributes are only used for intentional overrides (e.g., `role="group"` on the accordion to prevent the `toolbar` role).
 
 - [Index](https://microsoftedge.github.io/Demos/focusgroup/index.html): Overview page with a quick-demo toolbar and navigation to all demos
 - [Toolbar](https://microsoftedge.github.io/Demos/focusgroup/toolbar.html): Toolbar demos using inline and block navigation

--- a/focusgroup/README.md
+++ b/focusgroup/README.md
@@ -2,18 +2,20 @@
 
 ➡️ **[Open the demo](https://microsoftedge.github.io/Demos/focusgroup/)** ⬅️
 
-Interactive demos for the HTML `focusgroup` attribute, which provides declarative
-arrow-key keyboard navigation for composite widgets by implementing the _roving tabindex_ pattern natively without JavaScript.
+Interactive demos for the HTML `focusgroup` attribute, which lets you add arrow-key navigation to composite widgets (the roving tabindex pattern) without JavaScript.
 
 ## Demos
 
-- [Toolbar](https://microsoftedge.github.io/Demos/focusgroup/toolbar.html) — Horizontal/vertical toolbar with arrow-key navigation
-- [Tablist](https://microsoftedge.github.io/Demos/focusgroup/tablist.html) — Tab control with inline wrapping and no-memory
-- [Menu](https://microsoftedge.github.io/Demos/focusgroup/menu.html) — Vertical menu and menubar with nested submenus
-- [Radio Group](https://microsoftedge.github.io/Demos/focusgroup/radiogroup.html) — Radio button group navigation
-- [Listbox](https://microsoftedge.github.io/Demos/focusgroup/listbox.html) — Selectable list navigation
-- [Accordion](https://microsoftedge.github.io/Demos/focusgroup/accordion.html) — Accordion with block-axis navigation and opt-out panels
-- [Additional Concepts](https://microsoftedge.github.io/Demos/focusgroup/additional-concepts.html) — Nested focusgroups, opt-out, shadow DOM, reading-flow
+> **Note:** The `focusgroup` attribute only manages keyboard navigation. Explicit ARIA roles (`role="toolbar"`, `role="tablist"`, etc.) must be set separately.
+
+- [Index](https://microsoftedge.github.io/Demos/focusgroup/index.html): Overview page with a quick-demo toolbar and navigation to all demos
+- [Toolbar](https://microsoftedge.github.io/Demos/focusgroup/toolbar.html): Toolbar demos using inline and block navigation
+- [Tablist](https://microsoftedge.github.io/Demos/focusgroup/tablist.html): Tab control using the `tablist` behavior token (which defaults to inline + wrap), with `nomemory` to reset focus position on re-entry
+- [Menu](https://microsoftedge.github.io/Demos/focusgroup/menu.html): Vertical menu and horizontal menubar with nested submenus
+- [Radio Group](https://microsoftedge.github.io/Demos/focusgroup/radiogroup.html): Radio button group navigation
+- [Listbox](https://microsoftedge.github.io/Demos/focusgroup/listbox.html): Selectable list navigation
+- [Accordion](https://microsoftedge.github.io/Demos/focusgroup/accordion.html): Accordion with block-axis arrow key navigation using `focusgroup="toolbar block"` and `role="group"`
+- [Additional Concepts](https://microsoftedge.github.io/Demos/focusgroup/additional-concepts.html): Nested focusgroups, opt-out, deep descendants, CSS `reading-flow` integration, feature detection
 
 ## Learn more
 
@@ -22,4 +24,4 @@ arrow-key keyboard navigation for composite widgets by implementing the _roving 
 
 ## Requirements
 
-May require enabling the **Experimental Web Platform features** flag at `about://flags` in Microsoft Edge or another Chromium-based browser.
+These demos use the scoped-focusgroup variant of the spec and require enabling the **Experimental Web Platform features** flag at `about://flags` in Microsoft Edge or another Chromium-based browser. The feature is experimental and not yet enabled by default in stable builds. See the [Open UI explainer](https://open-ui.org/components/scoped-focusgroup.explainer/) for the spec status.

--- a/focusgroup/README.md
+++ b/focusgroup/README.md
@@ -6,7 +6,7 @@ Interactive demos for the HTML `focusgroup` attribute, which lets you add arrow-
 
 ## Demos
 
-> **Note:** The `focusgroup` attribute only manages keyboard navigation. Explicit ARIA roles (`role="toolbar"`, `role="tablist"`, etc.) must be set separately.
+> **Note:** The `focusgroup` behavior token maps a minimum ARIA role to generic containers (e.g., a plain `<div>`) and can infer child roles (e.g., `tab` on `<button>` inside a `tablist`). When you set an explicit `role` or use a non-generic element, the mapping is skipped. These demos set roles explicitly for clarity.
 
 - [Index](https://microsoftedge.github.io/Demos/focusgroup/index.html): Overview page with a quick-demo toolbar and navigation to all demos
 - [Toolbar](https://microsoftedge.github.io/Demos/focusgroup/toolbar.html): Toolbar demos using inline and block navigation

--- a/focusgroup/README.md
+++ b/focusgroup/README.md
@@ -11,7 +11,7 @@ Interactive demos for the HTML `focusgroup` attribute, which lets you add arrow-
 - [Index](https://microsoftedge.github.io/Demos/focusgroup/index.html): Overview page with a quick-demo toolbar and navigation to all demos
 - [Toolbar](https://microsoftedge.github.io/Demos/focusgroup/toolbar.html): Toolbar demos using inline and block navigation
 - [Tablist](https://microsoftedge.github.io/Demos/focusgroup/tablist.html): Tab control using the `tablist` behavior token (which defaults to inline + wrap), with `nomemory` to reset focus position on re-entry
-- [Menu](https://microsoftedge.github.io/Demos/focusgroup/menu.html): Vertical menu and horizontal menubar with nested submenus
+- [Menu & Menubar](https://microsoftedge.github.io/Demos/focusgroup/menu.html): Vertical menu and horizontal menubar with nested submenus
 - [Radio Group](https://microsoftedge.github.io/Demos/focusgroup/radiogroup.html): Radio button group navigation
 - [Listbox](https://microsoftedge.github.io/Demos/focusgroup/listbox.html): Selectable list navigation
 - [Accordion](https://microsoftedge.github.io/Demos/focusgroup/accordion.html): Accordion with block-axis arrow key navigation using `focusgroup="toolbar block"` and `role="group"`

--- a/focusgroup/accordion.html
+++ b/focusgroup/accordion.html
@@ -107,9 +107,9 @@
           Up/Down arrows only.</li>
         <li>The explicit <code>role="group"</code> overrides the minimum role that
           the <code>toolbar</code> behavior token would otherwise map
-          (<code>role="toolbar"</code>). Because an explicit role is present,
-          the behavior token's mapping is skipped and the container keeps
-          <code>role="group"</code>.</li>
+          (<code>role="toolbar"</code>). This is an intentional override;
+          most other demos rely on the behavior token's automatic role
+          mapping instead.</li>
         <li><code>focusgroup="none"</code> opts panel content out of arrow-key
           navigation.</li>
         <li>Up/Down arrows move <strong>only between headers</strong>, skipping panels

--- a/focusgroup/accordion.html
+++ b/focusgroup/accordion.html
@@ -49,8 +49,8 @@
               1: Getting Started</button></h3>
           <div focusgroup="none" role="region" id="acc-panel1" class="panel" aria-labelledby="acc-btn1">
             <p>
-              The <code>focusgroup</code> attribute provides
-              declarative arrow-key navigation for
+              The <code>focusgroup</code> attribute adds
+              declarative arrow-key navigation to
               composite widgets. Try these <a href="#">documentation
                 links</a>
               and <input type="text" placeholder="type here">.
@@ -101,14 +101,15 @@
       </div>
 
       <ul class="notice-list">
-        <li>The <code>focusgroup</code> spec requires a behavior token. <code>toolbar</code>
-          is the appropriate behavior token for accordion disclosure buttons, with
-          <code>block</code> overriding its default <code>inline</code> axis to restrict
-          navigation to Up/Down arrows only.</li>
-        <li>The explicit <code>role="group"</code> on the container prevents the browser
-          from inferring <code>role="toolbar"</code> (which <code>focusgroup="toolbar block"</code>
-          would otherwise apply to a plain <code>&lt;div&gt;</code>). Screen readers
-          announce the container as a group, not a toolbar.</li>
+        <li><code>toolbar</code> is used as the behavior token because it best matches
+          accordion disclosure buttons. <code>block</code>
+          overrides the default <code>inline</code> axis, changing navigation to
+          Up/Down arrows only.</li>
+        <li>The explicit <code>role="group"</code> overrides the minimum role that
+          the <code>toolbar</code> behavior token would otherwise map
+          (<code>role="toolbar"</code>). Because an explicit role is present,
+          the behavior token's mapping is skipped and the container keeps
+          <code>role="group"</code>.</li>
         <li><code>focusgroup="none"</code> opts panel content out of arrow-key
           navigation.</li>
         <li>Up/Down arrows move <strong>only between headers</strong>, skipping panels
@@ -134,9 +135,9 @@
                      Started&lt;/button&gt;
     &lt;/h3&gt;
     &lt;div focusgroup="none" role="region" id="acc-panel1"
-         aria-labelledby="acc-btn1"&gt;
+         class="panel" aria-labelledby="acc-btn1"&gt;
         &lt;p&gt;Panel content with &lt;a href="#"&gt;links&lt;/a&gt; and
-        &lt;input type="text" placeholder="inputs"&gt; that remain
+        &lt;input type="text" placeholder="type here"&gt; that remain
         tabbable but are skipped by arrow keys.&lt;/p&gt;
     &lt;/div&gt;
 
@@ -146,7 +147,7 @@
                      Configuration&lt;/button&gt;
     &lt;/h3&gt;
     &lt;div focusgroup="none" role="region" id="acc-panel2"
-         aria-labelledby="acc-btn2" hidden&gt;
+         class="panel" hidden aria-labelledby="acc-btn2"&gt;
         &lt;p&gt;More panel content...&lt;/p&gt;
     &lt;/div&gt;
 
@@ -156,7 +157,7 @@
                      Usage&lt;/button&gt;
     &lt;/h3&gt;
     &lt;div focusgroup="none" role="region" id="acc-panel3"
-         aria-labelledby="acc-btn3" hidden&gt;
+         class="panel" hidden aria-labelledby="acc-btn3"&gt;
         &lt;p&gt;Even more content...&lt;/p&gt;
     &lt;/div&gt;
     &lt;!-- more sections ... --&gt;
@@ -315,9 +316,9 @@
           constrained height)</li>
         <li><code>focusgroup="none"</code> on the panel prevents arrow
           keys from being consumed by the ancestor focusgroup</li>
-        <li><kbd>Shift+Tab</kbd> from the panel returns to the accordion
-          headers; <kbd>Tab</kbd> moves to the next open panel or past
-          the accordion</li>
+        <li><kbd>Shift+Tab</kbd> from the panel returns to the header that was
+          just expanded; <kbd>Tab</kbd> moves to the next header button or
+          into the next expanded panel</li>
         <li>This prevents long content from being silently skipped by
           focusgroup navigation</li>
       </ul>
@@ -339,19 +340,26 @@
     &lt;!-- more sections ... --&gt;
 &lt;/div&gt;
 
+&lt;!-- accordion.js handles all toggle and focus-into logic.
+     The key excerpt for focus-into behavior: --&gt;
 &lt;script&gt;
-// accordion.js handles aria-expanded, hidden, and focus-into.
-// On expand: aria-expanded="true" means the panel was just revealed.
-var accordion = document.querySelector(".accordion-focus-into");
-accordion.querySelectorAll("h3 button[aria-controls]").forEach(function (btn) {
+// excerpt from accordion.js: the focus-into enhancement
+// "accordion" is the current .accordion element from the outer forEach loop
+document.querySelectorAll(".accordion").forEach(function (accordion) {
+  var focusInto = accordion.classList.contains("accordion-focus-into");
+  accordion.querySelectorAll("h3 button[aria-controls]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-        if (btn.getAttribute("aria-expanded") === "true") {
-            var panel = document.getElementById(
-                btn.getAttribute("aria-controls")
-            );
-            if (panel) panel.focus();
+        var expanded = btn.getAttribute("aria-expanded") === "true";
+        btn.setAttribute("aria-expanded", String(!expanded));
+        btn.classList.toggle("expanded", !expanded);
+        var panel = document.getElementById(btn.getAttribute("aria-controls"));
+        if (panel) {
+            panel.hidden = expanded;
+            // On expand: move focus into the panel so arrow keys scroll
+            if (!expanded && focusInto) panel.focus();
         }
     });
+  });
 });
 &lt;/script&gt;</code></pre>
       </details>

--- a/focusgroup/accordion.html
+++ b/focusgroup/accordion.html
@@ -127,7 +127,7 @@
       <details class="source-code">
         <summary>View source</summary>
         <pre><code>&lt;div focusgroup="toolbar block" role="group"
-     aria-label="Accordion sections"&gt;
+     aria-label="Accordion sections" class="accordion"&gt;
     &lt;h3&gt;
         &lt;button id="acc-btn1" type="button" class="expanded" aria-expanded="true"
                 aria-controls="acc-panel1"&gt;Section 1: Getting
@@ -183,9 +183,8 @@
         (<code>tabindex="0"</code>) with
         <code>focusgroup="none"</code>, so arrow keys scroll its
         content instead of
-        jumping to the next header. The user can press <kbd>Tab</kbd>
-        to move back
-        to the accordion headers when they're done reading.
+        jumping to the next header. The user can press <kbd>Shift+Tab</kbd>
+        to return to the accordion headers when done reading.
         Other approaches (such as requiring an activation step before
         navigating away,
         showing a "skip to next section" link inside the panel, or
@@ -326,7 +325,7 @@
       <details class="source-code">
         <summary>View source</summary>
         <pre><code>&lt;div focusgroup="toolbar block" role="group"
-     aria-label="Articles"&gt;
+     aria-label="Articles" class="accordion accordion-focus-into"&gt;
     &lt;h3&gt;
         &lt;button id="long-btn1" type="button" aria-expanded="false"
                 aria-controls="long-panel1"&gt;The Focusgroup
@@ -341,13 +340,10 @@
 &lt;/div&gt;
 
 &lt;script&gt;
-// On expand, move focus into the panel so arrow keys scroll.
-// The full accordion script toggles aria-expanded and panel.hidden.
-// This enhancement moves focus to a newly expanded panel.
-// Read aria-expanded AFTER the main script has already toggled it:
-// aria-expanded="true" means the panel was just expanded.
+// accordion.js handles aria-expanded, hidden, and focus-into.
+// On expand: aria-expanded="true" means the panel was just revealed.
 var accordion = document.querySelector(".accordion-focus-into");
-accordion.querySelectorAll("h3 button").forEach(function (btn) {
+accordion.querySelectorAll("h3 button[aria-controls]").forEach(function (btn) {
     btn.addEventListener("click", function () {
         if (btn.getAttribute("aria-expanded") === "true") {
             var panel = document.getElementById(

--- a/focusgroup/accordion.html
+++ b/focusgroup/accordion.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Focusgroup: Accordion Pattern</title>
   <link rel="icon" type="image/png" href="https://edgestatic.azureedge.net/welcome/static/favicon.png">
@@ -33,7 +32,7 @@
         interactive elements inside panels
         remain reachable via <kbd>Tab</kbd>.
       </p>
-      <div class="attr-label">focusgroup="toolbar block"</div>
+      <div class="attr-label">focusgroup="toolbar block" role="group"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>↓</kbd> <kbd>↑</kbd> to move
@@ -46,27 +45,27 @@
 
       <div class="demo-container">
         <div focusgroup="toolbar block" role="group" aria-label="Accordion sections" class="accordion">
-          <h3><button type="button" class="expanded" aria-expanded="true" aria-controls="acc-panel1">Section
+          <h3><button id="acc-btn1" type="button" class="expanded" aria-expanded="true" aria-controls="acc-panel1">Section
               1: Getting Started</button></h3>
-          <div focusgroup="none" role="region" id="acc-panel1" class="panel" aria-label="Section 1 content">
+          <div focusgroup="none" role="region" id="acc-panel1" class="panel" aria-labelledby="acc-btn1">
             <p>
               The <code>focusgroup</code> attribute provides
               declarative arrow-key navigation for
               composite widgets. Try these <a href="#">documentation
                 links</a>
-              and <input type="text" placeholder="type here"> —
-              they're still reachable via Tab,
+              and <input type="text" placeholder="type here">.
+              They're still reachable via Tab,
               but arrow keys skip right over this panel.
             </p>
           </div>
 
-          <h3><button type="button" aria-expanded="false" aria-controls="acc-panel2">Section 2:
+          <h3><button id="acc-btn2" type="button" aria-expanded="false" aria-controls="acc-panel2">Section 2:
               Configuration</button></h3>
-          <div focusgroup="none" role="region" id="acc-panel2" class="panel" hidden aria-label="Section 2 content">
+          <div focusgroup="none" role="region" id="acc-panel2" class="panel" hidden aria-labelledby="acc-btn2">
             <p>
               Configure your focusgroup with tokens:
               <code>inline</code>, <code>block</code>,
-              <code>wrap</code>, <code>no-memory</code>, and
+              <code>wrap</code>, <code>nomemory</code>, and
               more. Check the
               <a href="#">focusgroup
                 explainer</a>
@@ -76,9 +75,9 @@
                 panel</button></p>
           </div>
 
-          <h3><button type="button" aria-expanded="false" aria-controls="acc-panel3">Section 3: Advanced
+          <h3><button id="acc-btn3" type="button" aria-expanded="false" aria-controls="acc-panel3">Section 3: Advanced
               Usage</button></h3>
-          <div focusgroup="none" role="region" id="acc-panel3" class="panel" hidden aria-label="Section 3 content">
+          <div focusgroup="none" role="region" id="acc-panel3" class="panel" hidden aria-labelledby="acc-btn3">
             <p>
               Explore nested focusgroups, grid navigation, and
               CSS <code>reading-flow</code> integration
@@ -87,9 +86,9 @@
             </p>
           </div>
 
-          <h3><button type="button" aria-expanded="false" aria-controls="acc-panel4">Section 4: Browser
+          <h3><button id="acc-btn4" type="button" aria-expanded="false" aria-controls="acc-panel4">Section 4: Browser
               Support</button></h3>
-          <div focusgroup="none" role="region" id="acc-panel4" class="panel" hidden aria-label="Section 4 content">
+          <div focusgroup="none" role="region" id="acc-panel4" class="panel" hidden aria-labelledby="acc-btn4">
             <p>
               The <code>focusgroup</code> attribute is
               experimental. Enable
@@ -102,24 +101,27 @@
       </div>
 
       <ul class="notice-list">
-        <li><code>role="group"</code> overrides the
-          <code>toolbar</code> role that the behavior token would
-          otherwise infer on the container
-        </li>
-        <li>The <code>&lt;button&gt;</code> items keep their native
-          <code>button</code> role — no child role override is needed
-          because the <code>toolbar</code> behavior has no child role
-          inference
-        </li>
-        <li><code>focusgroup="none"</code> opts panel content out of
-          arrow-key navigation</li>
-        <li>Up/Down arrows move <strong>only between headers</strong>,
-          skipping panels entirely</li>
-        <li><kbd>Tab</kbd> still reaches focusable content inside
-          expanded panels (links, inputs, buttons)</li>
+        <li>The <code>focusgroup</code> spec requires a behavior token. <code>toolbar</code>
+          is the appropriate behavior token for accordion disclosure buttons, with
+          <code>block</code> overriding its default <code>inline</code> axis to restrict
+          navigation to Up/Down arrows only.</li>
+        <li>The explicit <code>role="group"</code> on the container prevents the browser
+          from inferring <code>role="toolbar"</code> (which <code>focusgroup="toolbar block"</code>
+          would otherwise apply to a plain <code>&lt;div&gt;</code>). Screen readers
+          announce the container as a group, not a toolbar.</li>
+        <li><code>focusgroup="none"</code> opts panel content out of arrow-key
+          navigation.</li>
+        <li>Up/Down arrows move <strong>only between headers</strong>, skipping panels
+          entirely.</li>
+        <li><kbd>Tab</kbd> still reaches focusable content inside expanded panels
+          (links, inputs, buttons).</li>
         <li>JavaScript handles <code>aria-expanded</code> toggling and
-          <code>hidden</code> visibility
-        </li>
+          <code>hidden</code> visibility.</li>
+        <li><strong>Caution:</strong> Arrow key navigation in accordions is an
+          <em>optional enhancement</em> per the APG. <kbd>Tab</kbd> is the primary
+          and required navigation mechanism. When using this pattern, check that all
+          accordion buttons remain reachable by <kbd>Tab</kbd> and test with real
+          screen readers.</li>
       </ul>
 
       <details class="source-code">
@@ -127,33 +129,37 @@
         <pre><code>&lt;div focusgroup="toolbar block" role="group"
      aria-label="Accordion sections"&gt;
     &lt;h3&gt;
-        &lt;button type="button" class="expanded" aria-expanded="true"
+        &lt;button id="acc-btn1" type="button" class="expanded" aria-expanded="true"
                 aria-controls="acc-panel1"&gt;Section 1: Getting
                      Started&lt;/button&gt;
     &lt;/h3&gt;
-    &lt;div focusgroup="none" role="region" id="acc-panel1"&gt;
+    &lt;div focusgroup="none" role="region" id="acc-panel1"
+         aria-labelledby="acc-btn1"&gt;
         &lt;p&gt;Panel content with &lt;a href="#"&gt;links&lt;/a&gt; and
         &lt;input type="text" placeholder="inputs"&gt; that remain
         tabbable but are skipped by arrow keys.&lt;/p&gt;
     &lt;/div&gt;
 
     &lt;h3&gt;
-        &lt;button type="button" aria-expanded="false"
+        &lt;button id="acc-btn2" type="button" aria-expanded="false"
                 aria-controls="acc-panel2"&gt;Section 2:
                      Configuration&lt;/button&gt;
     &lt;/h3&gt;
-    &lt;div focusgroup="none" role="region" id="acc-panel2" hidden&gt;
+    &lt;div focusgroup="none" role="region" id="acc-panel2"
+         aria-labelledby="acc-btn2" hidden&gt;
         &lt;p&gt;More panel content...&lt;/p&gt;
     &lt;/div&gt;
 
     &lt;h3&gt;
-        &lt;button type="button" aria-expanded="false"
+        &lt;button id="acc-btn3" type="button" aria-expanded="false"
                 aria-controls="acc-panel3"&gt;Section 3: Advanced
                      Usage&lt;/button&gt;
     &lt;/h3&gt;
-    &lt;div focusgroup="none" role="region" id="acc-panel3" hidden&gt;
+    &lt;div focusgroup="none" role="region" id="acc-panel3"
+         aria-labelledby="acc-btn3" hidden&gt;
         &lt;p&gt;Even more content...&lt;/p&gt;
     &lt;/div&gt;
+    &lt;!-- more sections ... --&gt;
 &lt;/div&gt;</code></pre>
       </details>
     </section>
@@ -180,40 +186,39 @@
         jumping to the next header. The user can press <kbd>Tab</kbd>
         to move back
         to the accordion headers when they're done reading.
-        Other approaches — such as requiring an activation step before
+        Other approaches (such as requiring an activation step before
         navigating away,
         showing a "skip to next section" link inside the panel, or
         avoiding focusgroup
-        entirely for content-heavy accordions — may be more appropriate
+        entirely for content-heavy accordions) may be more appropriate
         depending on
         the use case.
       </p>
-      <div class="attr-label">focusgroup="toolbar block"</div>
+      <div class="attr-label">focusgroup="toolbar block" role="group"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Click a header or press
         <kbd>Enter</kbd>/<kbd>Space</kbd> to expand.
-        Focus moves into the panel — use <kbd>↓</kbd> <kbd>↑</kbd> to
+        Focus moves into the panel. Use <kbd>↓</kbd> <kbd>↑</kbd> to
         <strong>scroll</strong>
-        the long content. Press <kbd>Tab</kbd> to return to the
+        the long content. Press <kbd>Shift+Tab</kbd> to return to the
         accordion headers.
       </div>
 
       <div class="demo-container">
         <div focusgroup="toolbar block" role="group" aria-label="Articles" class="accordion accordion-focus-into">
-          <h3><button type="button" aria-expanded="false" aria-controls="long-panel1">The Focusgroup
+          <h3><button id="long-btn1" type="button" aria-expanded="false" aria-controls="long-panel1">The Focusgroup
               Problem</button></h3>
           <div focusgroup="none" role="region" tabindex="0" id="long-panel1" class="panel panel-scrollable" hidden
-            aria-label="The Focusgroup Problem">
+            aria-labelledby="long-btn1">
             <p>When focusgroup is used on an accordion, arrow keys
               navigate between
-              section headers. This provides fast movement through
-              the accordion — but
-              it also means that any content between headers is
+              section headers. Arrow keys move between headers quickly, but
+              any content between headers is
               <strong>completely
                 skipped</strong> by arrow-key navigation.
             </p>
-            <p>For short panels this is fine — the user can see the
+            <p>For short panels this is fine. The user can see the
               content without
               scrolling. But if a panel contains a lengthy article, a
               long list of
@@ -243,20 +248,19 @@
             </p>
           </div>
 
-          <h3><button type="button" aria-expanded="false" aria-controls="long-panel2">The Mitigation
+          <h3><button id="long-btn2" type="button" aria-expanded="false" aria-controls="long-panel2">The Mitigation
               Strategy</button></h3>
           <div focusgroup="none" role="region" tabindex="0" id="long-panel2" class="panel panel-scrollable" hidden
-            aria-label="The Mitigation Strategy">
+            aria-labelledby="long-btn2">
             <h4>Step 1: Make the panel focusable</h4>
             <p>Add <code>tabindex="0"</code> to the panel element.
               This makes it a
               focusable scrollable region. Screen readers will
               announce it as a region
-              with its <code>aria-label</code>.</p>
+              with its <code>aria-labelledby</code>.</p>
             <h4>Step 2: Opt out of the focusgroup</h4>
             <p>Add <code>focusgroup="none"</code> to the panel.
-              This ensures that
-              when the panel has focus, arrow keys scroll its content
+              When the panel has focus, arrow keys scroll its content
               rather than
               navigating the ancestor focusgroup.</p>
             <h4>Step 3: Move focus on expand</h4>
@@ -265,26 +269,19 @@
               moves focus to the panel. This puts the user directly
               into the content
               where arrow keys will scroll.</p>
-            <h4>Step 4: Let Tab return to headers</h4>
+            <h4>Step 4: Navigate back to headers with Shift+Tab</h4>
             <p>Because the panel is opted out of the focusgroup,
-              pressing
-              <kbd>Tab</kbd> exits the panel and enters the next
-              focusgroup segment.
-              The user is back on the accordion headers and can
-              arrow-navigate
-              to another section.
+              it is a separate tab stop.
+              <kbd>Shift+Tab</kbd> from the panel returns focus to the
+              accordion headers. <kbd>Tab</kbd> moves forward to the
+              next open panel or past the accordion.
             </p>
-            <p>This pattern ensures that long content is never
-              silently skipped,
-              while still preserving fast header-to-header navigation
-              when the user
-              wants it.</p>
           </div>
 
-          <h3><button type="button" aria-expanded="false" aria-controls="long-panel3">When To Use This
+          <h3><button id="long-btn3" type="button" aria-expanded="false" aria-controls="long-panel3">When To Use This
               Pattern</button></h3>
           <div focusgroup="none" role="region" tabindex="0" id="long-panel3" class="panel panel-scrollable" hidden
-            aria-label="When To Use This Pattern">
+            aria-labelledby="long-btn3">
             <p>Not every accordion needs this mitigation. Consider
               using it when:</p>
             <ul>
@@ -305,26 +302,23 @@
               <kbd>Tab</kbd> still reaches
               any interactive content inside.
             </p>
-            <p>The key question is: <em>will the user miss
-                important content if
-                arrow keys skip over this panel?</em> If the answer is
-              yes, use the
-              focus-into-panel mitigation shown here.</p>
+            <p>Use this mitigation when panel content is tall enough that a user arrowing past it would miss it.</p>
           </div>
         </div>
       </div>
 
       <ul class="notice-list">
-        <li>Expanding a section moves focus into the panel — arrow keys
+        <li>Expanding a section moves focus into the panel. Arrow keys
           now <strong>scroll content</strong> instead of jumping
-          headers</li>
+          between headers.</li>
         <li>The panel is a focusable scrollable region
           (<code>tabindex="0"</code> + <code>overflow: auto</code> +
           constrained height)</li>
-        <li><code>focusgroup="none"</code> on the panel ensures arrow
-          keys are not consumed by the ancestor focusgroup</li>
-        <li><kbd>Tab</kbd> exits the panel and returns to the accordion
-          headers</li>
+        <li><code>focusgroup="none"</code> on the panel prevents arrow
+          keys from being consumed by the ancestor focusgroup</li>
+        <li><kbd>Shift+Tab</kbd> from the panel returns to the accordion
+          headers; <kbd>Tab</kbd> moves to the next open panel or past
+          the accordion</li>
         <li>This prevents long content from being silently skipped by
           focusgroup navigation</li>
       </ul>
@@ -334,20 +328,25 @@
         <pre><code>&lt;div focusgroup="toolbar block" role="group"
      aria-label="Articles"&gt;
     &lt;h3&gt;
-        &lt;button type="button" aria-expanded="false"
+        &lt;button id="long-btn1" type="button" aria-expanded="false"
                 aria-controls="long-panel1"&gt;The Focusgroup
                      Problem&lt;/button&gt;
     &lt;/h3&gt;
     &lt;div focusgroup="none" role="region" tabindex="0"
-         id="long-panel1" class="panel-scrollable" hidden
-         aria-label="The Focusgroup Problem"&gt;
+         id="long-panel1" class="panel panel-scrollable" hidden
+         aria-labelledby="long-btn1"&gt;
         &lt;p&gt;Long panel content goes here...&lt;/p&gt;
     &lt;/div&gt;
     &lt;!-- more sections ... --&gt;
 &lt;/div&gt;
 
 &lt;script&gt;
-// On expand, move focus into the panel so arrow keys scroll
+// On expand, move focus into the panel so arrow keys scroll.
+// The full accordion script toggles aria-expanded and panel.hidden.
+// This enhancement moves focus to a newly expanded panel.
+// Read aria-expanded AFTER the main script has already toggled it:
+// aria-expanded="true" means the panel was just expanded.
+var accordion = document.querySelector(".accordion-focus-into");
 accordion.querySelectorAll("h3 button").forEach(function (btn) {
     btn.addEventListener("click", function () {
         if (btn.getAttribute("aria-expanded") === "true") {
@@ -367,7 +366,7 @@ accordion.querySelectorAll("h3 button").forEach(function (btn) {
       <p>
         The <code>none</code> value opts an element and its subtree out
         of the ancestor focusgroup.
-        This is crucial for composite widgets like accordions where:
+        The <code>none</code> value is what makes the accordion pattern work:
       </p>
       <ul>
         <li>You want arrow keys to move between <strong>headers

--- a/focusgroup/accordion.js
+++ b/focusgroup/accordion.js
@@ -1,5 +1,5 @@
 /* ============================================================
-   Focusgroup Demo — Accordion
+   Focusgroup Demo - Accordion
    ============================================================
    focusgroup handles arrow-key navigation between headers.
    This file handles the remaining application logic:
@@ -12,7 +12,7 @@
    focusable scrollable region (tabindex="0") with
    focusgroup="none", so arrow keys scroll its content.
 
-   Requires shared.js to be loaded first.
+   Load after shared.js for the focusgroup-support warning banner.
    ============================================================ */
 
 (function () {

--- a/focusgroup/additional-concepts.html
+++ b/focusgroup/additional-concepts.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Focusgroup: Additional Concepts</title>
   <link rel="icon" type="image/png" href="https://edgestatic.azureedge.net/welcome/static/favicon.png">
@@ -32,21 +31,21 @@
         <kbd>Tab</kbd> moves between groups;
         arrows navigate within.
       </p>
-      <div class="attr-label">focusgroup="toolbar inline" (outer) +
-        focusgroup="toolbar inline wrap" (inner)</div>
+      <div class="attr-label">focusgroup="toolbar" role="toolbar" (outer) +
+        focusgroup="toolbar" role="group" (inner)</div>
 
       <div class="try-it">
-        <strong>Try it:</strong> Use <kbd>→</kbd> in the outer toolbar.
-        When focus reaches the nested group, press <kbd>Tab</kbd>
-        to enter it. Use arrows inside, then <kbd>Tab</kbd> to exit
-        back to the outer toolbar.
+        <strong>Try it:</strong> Use <kbd>→</kbd> to navigate the outer
+        toolbar; arrows skip the nested group. Press <kbd>Tab</kbd>
+        to enter the nested group; once inside, use arrows. Press
+        <kbd>Tab</kbd> again to exit.
       </div>
 
       <div class="demo-container">
-        <div focusgroup="toolbar inline" aria-label="Main toolbar" class="toolbar-horizontal">
+        <div role="toolbar" focusgroup="toolbar" aria-label="Main toolbar" class="toolbar-horizontal">
           <button type="button">Save</button>
-          <button type="button" focusgroupstart>Print</button>
-          <div focusgroup="toolbar inline wrap" aria-label="Text formatting" class="nested-toolbar">
+          <button type="button">Print</button>
+          <div role="group" focusgroup="toolbar" aria-label="Text formatting" class="nested-toolbar">
             <button type="button">Bold</button>
             <button type="button">Italic</button>
             <button type="button">Underline</button>
@@ -57,23 +56,25 @@
       </div>
 
       <ul class="notice-list">
-        <li>The nested toolbar is an <strong>independent scope</strong>
-          inside the outer toolbar</li>
         <li><kbd>Tab</kbd> moves between the outer and inner
           focusgroups</li>
         <li>Arrow keys navigate within whichever group currently has
           focus</li>
-        <li>Each group can have its own wrapping/memory/axis
-          settings</li>
+        <li>Sub-groups within a toolbar use <code>role="group"</code>
+          rather than another <code>role="toolbar"</code>, as nesting
+          toolbars is architecturally unsound. Per spec, the browser skips
+          minimum-role inference (<code>role="toolbar"</code>) when an
+          explicit <code>role</code> is present; arrow-key navigation still
+          activates on the inner group.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="toolbar inline" aria-label="Main
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Main
      toolbar"&gt;
     &lt;button type="button"&gt;Save&lt;/button&gt;
-    &lt;button type="button" focusgroupstart&gt;Print&lt;/button&gt;
-    &lt;div focusgroup="toolbar inline wrap" aria-label="Text formatting"&gt;
+    &lt;button type="button"&gt;Print&lt;/button&gt;
+    &lt;div role="group" focusgroup="toolbar" aria-label="Text formatting"&gt;
         &lt;button type="button"&gt;Bold&lt;/button&gt;
         &lt;button type="button"&gt;Italic&lt;/button&gt;
         &lt;button type="button"&gt;Underline&lt;/button&gt;
@@ -90,11 +91,11 @@
     <section class="demo-section">
       <h2 id="opt-out-segments-with-focusgroup-none">Opt-Out Segments with <code>focusgroup="none"</code></h2>
       <p>
-        Use <code>focusgroup="none"</code> to exclude specific elements
-        from arrow navigation
-        while keeping them tabbable. Arrow keys skip right over them.
+        Use <code>focusgroup="none"</code> to exclude a subtree's focusable
+        descendants from arrow navigation while keeping them reachable
+        via <kbd>Tab</kbd>.
       </p>
-      <div class="attr-label">focusgroup="toolbar inline"</div>
+      <div class="attr-label">focusgroup="toolbar"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>→</kbd> to navigate through
@@ -104,7 +105,7 @@
       </div>
 
       <div class="demo-container">
-        <div focusgroup="toolbar inline" aria-label="Segmented toolbar" class="toolbar-horizontal">
+        <div role="toolbar" focusgroup="toolbar" aria-label="Segmented toolbar" class="toolbar-horizontal">
           <button type="button">New</button>
           <button type="button">Open</button>
           <button type="button">Save</button>
@@ -128,12 +129,12 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="toolbar inline"
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar"
      aria-label="Segmented toolbar"&gt;
     &lt;button type="button"&gt;New&lt;/button&gt;
     &lt;button type="button"&gt;Open&lt;/button&gt;
     &lt;button type="button"&gt;Save&lt;/button&gt;
-    &lt;span focusgroup="none"&gt;
+    &lt;span focusgroup="none" style="display: contents;"&gt;
         &lt;button type="button"&gt;Help&lt;/button&gt;
         &lt;button type="button"&gt;Shortcuts&lt;/button&gt;
     &lt;/span&gt;
@@ -144,27 +145,27 @@
     </section>
 
     <!-- ============================================================ -->
-    <!-- Demo 3: Deep Descendant Discovery -->
+    <!-- Demo 3: Deep Descendants -->
     <!-- ============================================================ -->
     <section class="demo-section">
-      <h2 id="deep-descendant-discovery">Deep Descendant Discovery</h2>
+      <h2 id="deep-descendant-discovery">Deep Descendants</h2>
       <p>
         Focusgroup items don't need to be direct children. The browser
         discovers focusable
         descendants at any depth (unless they are inside a nested
         focusgroup or <code>focusgroup="none"</code>).
       </p>
-      <div class="attr-label">focusgroup="toolbar inline"</div>
+      <div class="attr-label">focusgroup="toolbar"</div>
 
       <div class="try-it">
-        <strong>Try it:</strong> Use <kbd>→</kbd> <kbd>←</kbd> — arrow
-        navigation works even though buttons are deeply nested
+        <strong>Try it:</strong> Use <kbd>→</kbd> <kbd>←</kbd> to
+        navigate. Arrow navigation works even though buttons are deeply nested
         inside <code>&lt;div&gt;</code> and
         <code>&lt;span&gt;</code> wrappers.
       </div>
 
       <div class="demo-container">
-        <div focusgroup="toolbar inline" aria-label="Nested wrappers" class="toolbar-horizontal">
+        <div role="toolbar" focusgroup="toolbar" aria-label="Nested wrappers" class="toolbar-horizontal">
           <div>
             <span><button type="button">Alpha</button></span>
             <span><button type="button">Beta</button></span>
@@ -174,17 +175,13 @@
       </div>
 
       <ul class="notice-list">
-        <li>Buttons are nested inside
-          <code>&lt;div&gt;&lt;span&gt;</code> wrappers
-        </li>
-        <li>Focusgroup discovers them at any depth in the DOM tree</li>
-        <li>No flat list requirement — wrapper elements for styling are
+        <li>No flat list requirement; wrapper elements for styling are
           fine</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="toolbar inline"
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar"
      aria-label="Nested wrappers"&gt;
     &lt;div&gt;
         &lt;span&gt;&lt;button
@@ -220,7 +217,7 @@
       </div>
 
       <div class="demo-container">
-        <div focusgroup="toolbar" aria-label="Visual order" style="display: flex; flex-direction: row-reverse;
+        <div role="toolbar" focusgroup="toolbar" aria-label="Visual order" style="display: flex; flex-direction: row-reverse;
                          reading-flow: flex-visual; gap: 0.35rem;">
           <button type="button">A (DOM first)</button>
           <button type="button">B (DOM second)</button>
@@ -229,19 +226,17 @@
       </div>
 
       <ul class="notice-list">
-        <li>DOM order: A, B, C — but <code>flex-direction:
-                    row-reverse</code> visually renders C, B, A</li>
         <li><code>reading-flow: flex-visual</code> tells focusgroup to
           follow visual order</li>
         <li>Right arrow from C goes to B, then A (visual
           left-to-right)</li>
-        <li>Without <code>reading-flow</code>, arrow keys would follow
-          DOM order (A → B → C), which is visually backwards</li>
+        <li>Without <code>reading-flow</code>, arrow keys follow
+          DOM order (A → B → C).</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="toolbar" aria-label="Visual
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Visual
      order"
      style="display: flex; flex-direction: row-reverse;
             reading-flow: flex-visual;"&gt;
@@ -272,10 +267,10 @@
         <summary>View source</summary>
         <pre><code>&lt;script&gt;
 if ('focusgroup' in HTMLElement.prototype) {
-    // focusgroup is supported — use it!
+    // focusgroup is supported - use it!
     console.log('focusgroup is supported');
 } else {
-    // Not supported — fall back to JS roving tabindex
+    // Not supported - fall back to JS roving tabindex
     console.log('focusgroup is NOT supported');
 }
 &lt;/script&gt;</code></pre>
@@ -291,13 +286,11 @@ if ('focusgroup' in HTMLElement.prototype) {
       var result = document.getElementById("feature-detect-result");
       if (!result) return;
       if ("focusgroup" in HTMLElement.prototype) {
-        result.textContent = "✅ focusgroup IS supported in this
-        browser.";
+        result.textContent = "✅ focusgroup IS supported in this browser.";
         result.style.background = "var(--accent-light)";
         result.style.color = "var(--success)";
       } else {
-        result.textContent = "❌ focusgroup is NOT supported in this
-        browser.Enable experimental flags to try these demos.";
+        result.textContent = "❌ focusgroup is NOT supported in this browser. Enable experimental flags to try these demos.";
         result.style.background = "var(--warning-bg)";
         result.style.color = "var(--warning-text)";
       }

--- a/focusgroup/additional-concepts.html
+++ b/focusgroup/additional-concepts.html
@@ -31,7 +31,7 @@
         <kbd>Tab</kbd> moves between groups;
         arrows navigate within.
       </p>
-      <div class="attr-label">focusgroup="toolbar" role="toolbar" (outer) +
+      <div class="attr-label" aria-hidden="true">focusgroup="toolbar" (outer) +
         focusgroup="toolbar" role="group" (inner)</div>
 
       <div class="try-it">
@@ -70,8 +70,7 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Main
-     toolbar"&gt;
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Main toolbar"&gt;
     &lt;button type="button"&gt;Save&lt;/button&gt;
     &lt;button type="button"&gt;Print&lt;/button&gt;
     &lt;div role="group" focusgroup="toolbar" aria-label="Text formatting"&gt;
@@ -95,7 +94,7 @@
         descendants from arrow navigation while keeping them reachable
         via <kbd>Tab</kbd>.
       </p>
-      <div class="attr-label">focusgroup="toolbar"</div>
+      <div class="attr-label" aria-hidden="true">focusgroup="toolbar"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>→</kbd> to navigate through
@@ -155,7 +154,7 @@
         descendants at any depth (unless they are inside a nested
         focusgroup or <code>focusgroup="none"</code>).
       </p>
-      <div class="attr-label">focusgroup="toolbar"</div>
+      <div class="attr-label" aria-hidden="true">focusgroup="toolbar"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>→</kbd> <kbd>←</kbd> to
@@ -206,7 +205,7 @@
         follow the <strong>visual</strong>
         order rather than the DOM source order.
       </p>
-      <div class="attr-label">focusgroup="toolbar" + reading-flow:
+      <div class="attr-label" aria-hidden="true">focusgroup="toolbar" + reading-flow:
         flex-visual</div>
 
       <div class="try-it">
@@ -231,13 +230,12 @@
         <li>Right arrow from C goes to B, then A (visual
           left-to-right)</li>
         <li>Without <code>reading-flow</code>, arrow keys follow
-          DOM order (A → B → C).</li>
+          DOM order (A → B → C)</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Visual
-     order"
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Visual order"
      style="display: flex; flex-direction: row-reverse;
             reading-flow: flex-visual;"&gt;
     &lt;button type="button"&gt;A (DOM first)&lt;/button&gt;

--- a/focusgroup/additional-concepts.html
+++ b/focusgroup/additional-concepts.html
@@ -41,7 +41,7 @@
       </div>
 
       <div class="demo-container">
-        <div role="toolbar" focusgroup="toolbar" aria-label="Main toolbar" class="toolbar-horizontal">
+        <div focusgroup="toolbar" aria-label="Main toolbar" class="toolbar-horizontal">
           <button type="button">Save</button>
           <button type="button">Print</button>
           <div role="group" focusgroup="toolbar" tabindex="0" aria-label="Text formatting" class="nested-toolbar">
@@ -67,7 +67,7 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Main toolbar"
+        <pre><code>&lt;div focusgroup="toolbar" aria-label="Main toolbar"
      class="toolbar-horizontal"&gt;
     &lt;button type="button"&gt;Save&lt;/button&gt;
     &lt;button type="button"&gt;Print&lt;/button&gt;
@@ -103,13 +103,13 @@
       </div>
 
       <div class="demo-container">
-        <div role="toolbar" focusgroup="toolbar" aria-label="Segmented toolbar" class="toolbar-horizontal">
+        <div focusgroup="toolbar" aria-label="Segmented toolbar" class="toolbar-horizontal">
           <button type="button">New</button>
           <button type="button">Open</button>
           <button type="button">Save</button>
           <span focusgroup="none">
-            <button type="button" style="opacity: 0.6;">Help</button>
-            <button type="button" style="opacity: 0.6;">Shortcuts</button>
+            <button type="button" class="opted-out-button">Help</button>
+            <button type="button" class="opted-out-button">Shortcuts</button>
           </span>
           <button type="button">Close</button>
           <button type="button">Exit</button>
@@ -127,14 +127,14 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar"
+        <pre><code>&lt;div focusgroup="toolbar"
      aria-label="Segmented toolbar" class="toolbar-horizontal"&gt;
     &lt;button type="button"&gt;New&lt;/button&gt;
     &lt;button type="button"&gt;Open&lt;/button&gt;
     &lt;button type="button"&gt;Save&lt;/button&gt;
     &lt;span focusgroup="none"&gt;
-        &lt;button type="button" style="opacity: 0.6;"&gt;Help&lt;/button&gt;
-        &lt;button type="button" style="opacity: 0.6;"&gt;Shortcuts&lt;/button&gt;
+        &lt;button type="button" class="opted-out-button"&gt;Help&lt;/button&gt;
+        &lt;button type="button" class="opted-out-button"&gt;Shortcuts&lt;/button&gt;
     &lt;/span&gt;
     &lt;button type="button"&gt;Close&lt;/button&gt;
     &lt;button type="button"&gt;Exit&lt;/button&gt;
@@ -163,7 +163,7 @@
       </div>
 
       <div class="demo-container">
-        <div role="toolbar" focusgroup="toolbar" aria-label="Nested wrappers" class="toolbar-horizontal">
+        <div focusgroup="toolbar" aria-label="Nested wrappers" class="toolbar-horizontal">
           <div>
             <span><button type="button">Alpha</button></span>
             <span><button type="button">Beta</button></span>
@@ -179,7 +179,7 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar"
+        <pre><code>&lt;div focusgroup="toolbar"
      aria-label="Nested wrappers" class="toolbar-horizontal"&gt;
     &lt;div&gt;
         &lt;span&gt;&lt;button type="button"&gt;Alpha&lt;/button&gt;&lt;/span&gt;
@@ -211,8 +211,7 @@
       </div>
 
       <div class="demo-container">
-        <div role="toolbar" focusgroup="toolbar" aria-label="Visual order" style="display: flex; flex-direction: row-reverse;
-                         reading-flow: flex-visual; gap: 0.35rem;">
+        <div focusgroup="toolbar" aria-label="Visual order" class="reading-flow-toolbar">
           <button type="button">A (DOM first)</button>
           <button type="button">B (DOM second)</button>
           <button type="button">C (DOM third)</button>
@@ -230,9 +229,8 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Visual order"
-     style="display: flex; flex-direction: row-reverse;
-            reading-flow: flex-visual; gap: 0.35rem;"&gt;
+        <pre><code>&lt;div focusgroup="toolbar" aria-label="Visual order"
+     class="reading-flow-toolbar"&gt;
     &lt;button type="button"&gt;A (DOM first)&lt;/button&gt;
     &lt;button type="button"&gt;B (DOM second)&lt;/button&gt;
     &lt;button type="button"&gt;C (DOM third)&lt;/button&gt;
@@ -253,7 +251,7 @@
       </p>
 
       <div class="demo-container">
-        <div id="feature-detect-result" style="padding: 0.75rem; border-radius: 4px;"></div>
+        <div id="feature-detect-result"></div>
       </div>
 
       <details class="source-code">

--- a/focusgroup/additional-concepts.html
+++ b/focusgroup/additional-concepts.html
@@ -132,7 +132,7 @@
     &lt;button type="button"&gt;New&lt;/button&gt;
     &lt;button type="button"&gt;Open&lt;/button&gt;
     &lt;button type="button"&gt;Save&lt;/button&gt;
-    &lt;span focusgroup="none" style="display: contents;"&gt;
+    &lt;span focusgroup="none"&gt;
         &lt;button type="button" style="opacity: 0.6;"&gt;Help&lt;/button&gt;
         &lt;button type="button" style="opacity: 0.6;"&gt;Shortcuts&lt;/button&gt;
     &lt;/span&gt;

--- a/focusgroup/additional-concepts.html
+++ b/focusgroup/additional-concepts.html
@@ -28,24 +28,23 @@
         A nested focusgroup creates an independent navigation scope
         within an outer focusgroup.
         Each group has its own axis, wrapping, memory, and entry point.
-        <kbd>Tab</kbd> moves between groups;
-        arrows navigate within.
+        Each focusgroup is its own tab stop; arrows navigate within the active group.
       </p>
-      <div class="attr-label" aria-hidden="true">focusgroup="toolbar" (outer) +
-        focusgroup="toolbar" role="group" (inner)</div>
+      <div class="attr-label" aria-hidden="true">focusgroup="toolbar" (outer) + focusgroup="toolbar" + role="group" (inner)</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>→</kbd> to navigate the outer
-        toolbar; arrows skip the nested group. Press <kbd>Tab</kbd>
-        to enter the nested group; once inside, use arrows. Press
-        <kbd>Tab</kbd> again to exit.
+        toolbar; the nested group counts as a <strong>single stop</strong>;
+        arrows land on it as a whole. Press <kbd>Tab</kbd>
+        to move focus inside the nested group; once inside, use
+        arrows. Press <kbd>Tab</kbd> again to exit.
       </div>
 
       <div class="demo-container">
         <div role="toolbar" focusgroup="toolbar" aria-label="Main toolbar" class="toolbar-horizontal">
           <button type="button">Save</button>
           <button type="button">Print</button>
-          <div role="group" focusgroup="toolbar" aria-label="Text formatting" class="nested-toolbar">
+          <div role="group" focusgroup="toolbar" tabindex="0" aria-label="Text formatting" class="nested-toolbar">
             <button type="button">Bold</button>
             <button type="button">Italic</button>
             <button type="button">Underline</button>
@@ -56,24 +55,24 @@
       </div>
 
       <ul class="notice-list">
-        <li><kbd>Tab</kbd> moves between the outer and inner
-          focusgroups</li>
+        <li>Each focusgroup is a separate tab stop in the page's tab order</li>
         <li>Arrow keys navigate within whichever group currently has
           focus</li>
         <li>Sub-groups within a toolbar use <code>role="group"</code>
           rather than another <code>role="toolbar"</code>, as nesting
-          toolbars is architecturally unsound. Per spec, the browser skips
-          minimum-role inference (<code>role="toolbar"</code>) when an
-          explicit <code>role</code> is present; arrow-key navigation still
-          activates on the inner group.</li>
+          toolbars is architecturally unsound. Arrow-key navigation
+          works on the inner group regardless of which
+          explicit <code>role</code> it carries.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Main toolbar"&gt;
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Main toolbar"
+     class="toolbar-horizontal"&gt;
     &lt;button type="button"&gt;Save&lt;/button&gt;
     &lt;button type="button"&gt;Print&lt;/button&gt;
-    &lt;div role="group" focusgroup="toolbar" aria-label="Text formatting"&gt;
+    &lt;div role="group" focusgroup="toolbar" tabindex="0" aria-label="Text formatting"
+         class="nested-toolbar"&gt;
         &lt;button type="button"&gt;Bold&lt;/button&gt;
         &lt;button type="button"&gt;Italic&lt;/button&gt;
         &lt;button type="button"&gt;Underline&lt;/button&gt;
@@ -129,13 +128,13 @@
       <details class="source-code">
         <summary>View source</summary>
         <pre><code>&lt;div role="toolbar" focusgroup="toolbar"
-     aria-label="Segmented toolbar"&gt;
+     aria-label="Segmented toolbar" class="toolbar-horizontal"&gt;
     &lt;button type="button"&gt;New&lt;/button&gt;
     &lt;button type="button"&gt;Open&lt;/button&gt;
     &lt;button type="button"&gt;Save&lt;/button&gt;
     &lt;span focusgroup="none" style="display: contents;"&gt;
-        &lt;button type="button"&gt;Help&lt;/button&gt;
-        &lt;button type="button"&gt;Shortcuts&lt;/button&gt;
+        &lt;button type="button" style="opacity: 0.6;"&gt;Help&lt;/button&gt;
+        &lt;button type="button" style="opacity: 0.6;"&gt;Shortcuts&lt;/button&gt;
     &lt;/span&gt;
     &lt;button type="button"&gt;Close&lt;/button&gt;
     &lt;button type="button"&gt;Exit&lt;/button&gt;
@@ -181,13 +180,11 @@
       <details class="source-code">
         <summary>View source</summary>
         <pre><code>&lt;div role="toolbar" focusgroup="toolbar"
-     aria-label="Nested wrappers"&gt;
+     aria-label="Nested wrappers" class="toolbar-horizontal"&gt;
     &lt;div&gt;
-        &lt;span&gt;&lt;button
-             type="button"&gt;Alpha&lt;/button&gt;&lt;/span&gt;
+        &lt;span&gt;&lt;button type="button"&gt;Alpha&lt;/button&gt;&lt;/span&gt;
         &lt;span&gt;&lt;button type="button"&gt;Beta&lt;/button&gt;&lt;/span&gt;
-        &lt;span&gt;&lt;button
-             type="button"&gt;Gamma&lt;/button&gt;&lt;/span&gt;
+        &lt;span&gt;&lt;button type="button"&gt;Gamma&lt;/button&gt;&lt;/span&gt;
     &lt;/div&gt;
 &lt;/div&gt;</code></pre>
       </details>
@@ -199,14 +196,12 @@
     <section class="demo-section">
       <h2 id="css-reading-flow-integration">CSS <code>reading-flow</code> Integration</h2>
       <p>
-        When CSS changes the visual order (e.g., <code>flex-direction:
-                    row-reverse</code>),
-        <code>reading-flow: flex-visual</code> tells the focusgroup to
-        follow the <strong>visual</strong>
-        order rather than the DOM source order.
+        When <code>reading-flow: flex-visual</code> is set, the browser
+        uses the visual flex order for all focus navigation,
+        including <code>focusgroup</code> arrow keys, rather than
+        DOM source order.
       </p>
-      <div class="attr-label" aria-hidden="true">focusgroup="toolbar" + reading-flow:
-        flex-visual</div>
+      <div class="attr-label" aria-hidden="true">focusgroup="toolbar" + reading-flow: flex-visual</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>→</kbd> to navigate. With
@@ -225,8 +220,8 @@
       </div>
 
       <ul class="notice-list">
-        <li><code>reading-flow: flex-visual</code> tells focusgroup to
-          follow visual order</li>
+        <li><code>reading-flow: flex-visual</code> makes the browser use
+          visual flex order for focus navigation (Tab and arrow keys)</li>
         <li>Right arrow from C goes to B, then A (visual
           left-to-right)</li>
         <li>Without <code>reading-flow</code>, arrow keys follow
@@ -237,7 +232,7 @@
         <summary>View source</summary>
         <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Visual order"
      style="display: flex; flex-direction: row-reverse;
-            reading-flow: flex-visual;"&gt;
+            reading-flow: flex-visual; gap: 0.35rem;"&gt;
     &lt;button type="button"&gt;A (DOM first)&lt;/button&gt;
     &lt;button type="button"&gt;B (DOM second)&lt;/button&gt;
     &lt;button type="button"&gt;C (DOM third)&lt;/button&gt;

--- a/focusgroup/additional-concepts.html
+++ b/focusgroup/additional-concepts.html
@@ -107,7 +107,7 @@
           <button type="button">New</button>
           <button type="button">Open</button>
           <button type="button">Save</button>
-          <span focusgroup="none" style="display: contents;">
+          <span focusgroup="none">
             <button type="button" style="opacity: 0.6;">Help</button>
             <button type="button" style="opacity: 0.6;">Shortcuts</button>
           </span>

--- a/focusgroup/index.html
+++ b/focusgroup/index.html
@@ -17,7 +17,7 @@
   </header>
 
   <main class="page-content">
-    <!-- Feature detection warning inserted here by script.js if
+    <!-- Feature detection warning inserted here by shared.js if
             unsupported -->
 
     <section class="demo-section">
@@ -43,15 +43,12 @@
         boundary behavior and axis restriction.
       </p>
       <p>
-        The <code>focusgroup</code> attribute manages keyboard navigation
-        only. For elements with an explicit <code>role</code> attribute or
-        non-generic native semantics (such as <code>&lt;ul&gt;</code> or
-        <code>&lt;nav&gt;</code>), the browser does not override or infer a
-        role. For plain <code>&lt;div&gt;</code> elements without an explicit
-        role, the behavior token's minimum role is inferred automatically
-        (e.g., <code>focusgroup="toolbar"</code> on a <code>&lt;div&gt;</code>
-        infers <code>role="toolbar"</code>). In either case, set
-        <code>role</code> attributes explicitly to keep authoring intent clear.
+        The <code>focusgroup</code> attribute manages keyboard navigation.
+        Its behavior token also maps a minimum ARIA role to the container
+        (and may infer child roles, e.g. <code>tab</code> on buttons inside
+        a <code>tablist</code>) when no explicit <code>role</code> is present
+        and the element is otherwise generic. When you set <code>role</code>
+        explicitly, as these demos do, the mapping is skipped.
       </p>
     </section>
 
@@ -82,11 +79,11 @@
     <section class="demo-section">
       <h2 id="explore-the-demos">Explore the Demos</h2>
       <nav aria-labelledby="explore-the-demos">
-        <p class="sr-only">Use arrow keys to navigate between demo cards.</p>
-        <!-- <ul> has non-generic native semantics, so the browser skips
-             role mapping and the element retains role="list". focusgroup
-             navigation (inline arrow keys) still activates. -->
-        <ul class="card-grid" focusgroup="toolbar wrap">
+        <p class="sr-only" id="card-nav-hint">Use Left and Right arrow keys to navigate between demo cards.</p>
+        <!-- toolbar behavior token gives arrow-key navigation; role="list" prevents the
+             minimum-role mapping from applying (non-generic element), but we add it
+             explicitly so the intent is clear. -->
+        <ul class="card-grid" role="list" focusgroup="toolbar wrap" aria-describedby="card-nav-hint">
           <li>
             <a href="toolbar.html" class="card-link">
               <h3>Toolbar</h3>
@@ -116,8 +113,7 @@
               <h3>Radio Group</h3>
               <p>Custom radio button groups with arrow-key
                 navigation, compared to native radios.</p>
-              <span class="attr-label" aria-hidden="true">focusgroup="radiogroup"
-              </span>
+              <span class="attr-label" aria-hidden="true">focusgroup="radiogroup"</span>
             </a>
           </li>
           <li>
@@ -125,8 +121,7 @@
               <h3>Listbox</h3>
               <p>Selectable list with vertical navigation and
                 selection management.</p>
-              <span class="attr-label" aria-hidden="true">focusgroup="listbox
-                block"</span>
+              <span class="attr-label" aria-hidden="true">focusgroup="listbox block"</span>
             </a>
           </li>
           <li>
@@ -142,7 +137,7 @@
               <h3>Additional Concepts</h3>
               <p>Nested focusgroups, opt-out, deep descendants,
                 reading-flow, and feature detection.</p>
-              <span class="attr-label" aria-hidden="true">focusgroup="none"</span>
+              <span class="attr-label" aria-hidden="true">nested · opt-out · reading-flow</span>
             </a>
           </li>
         </ul>

--- a/focusgroup/index.html
+++ b/focusgroup/index.html
@@ -44,7 +44,7 @@
       </p>
       <p>
         The <code>focusgroup</code> attribute manages keyboard navigation
-        only. For elements with an explicit <code>role=</code> attribute or
+        only. For elements with an explicit <code>role</code> attribute or
         non-generic native semantics (such as <code>&lt;ul&gt;</code> or
         <code>&lt;nav&gt;</code>), the browser does not override or infer a
         role. For plain <code>&lt;div&gt;</code> elements without an explicit
@@ -70,7 +70,7 @@
           <button type="button">Link</button>
         </div>
       </div>
-      <div class="attr-label">focusgroup="toolbar wrap"</div>
+      <div class="attr-label" aria-hidden="true">focusgroup="toolbar wrap"</div>
       <ul class="notice-list">
         <li>The entire toolbar is <strong>one tab stop</strong></li>
         <li>Left/Right arrows move focus between buttons</li>

--- a/focusgroup/index.html
+++ b/focusgroup/index.html
@@ -47,8 +47,11 @@
         Its behavior token also maps a minimum ARIA role to the container
         (and may infer child roles, e.g. <code>tab</code> on buttons inside
         a <code>tablist</code>) when no explicit <code>role</code> is present
-        and the element is otherwise generic. When you set <code>role</code>
-        explicitly, as these demos do, the mapping is skipped.
+        and the element is otherwise generic. These demos rely on the
+        behavior token for role mapping. Explicit <code>role</code>
+        attributes are only used when overriding the default (e.g.,
+        <code>role="group"</code> on an accordion to prevent the
+        <code>toolbar</code> role).
       </p>
     </section>
 
@@ -59,7 +62,7 @@
         exit.
       </p>
       <div class="demo-container">
-        <div role="toolbar" focusgroup="toolbar wrap" aria-label="Quick demo toolbar" class="toolbar-horizontal">
+        <div focusgroup="toolbar wrap" aria-label="Quick demo toolbar" class="toolbar-horizontal">
           <button type="button">Bold</button>
           <button type="button">Italic</button>
           <button type="button">Underline</button>

--- a/focusgroup/index.html
+++ b/focusgroup/index.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Focusgroup: Interactive Demos</title>
   <link rel="icon" type="image/png" href="https://edgestatic.azureedge.net/welcome/static/favicon.png">
@@ -13,7 +12,7 @@
 <body>
   <header class="page-header">
     <h1>Focusgroup: Interactive Demos</h1>
-    <p>Declarative arrow-key keyboard navigation for composite widgets — no
+    <p>Declarative arrow-key keyboard navigation for composite widgets. No
       JavaScript required.</p>
   </header>
 
@@ -26,43 +25,44 @@
       <p>
         The <code>focusgroup</code> HTML attribute lets you add
         arrow-key navigation to groups of
-        focusable elements — implementing the <strong>"roving tabindex"
+        focusable elements, implementing the <strong>"roving tabindex"
           pattern</strong> natively
         without writing any JavaScript for focus management.
       </p>
       <p>
         Composite widgets like toolbars, tablists, menus, radio groups,
-        and listboxes typically need
-        arrow-key navigation so they behave as a single tab stop.
-        Traditionally, this required
-        significant JS to manage focus with the "roving tabindex"
-        pattern. With <code>focusgroup</code>, you
-        simply add an attribute and the browser handles everything:
+        and listboxes typically need arrow-key navigation so they behave
+        as a single tab stop. With <code>focusgroup</code>, you add the
+        attribute and the browser manages focus.
       </p>
-      <ul>
-        <li><strong>Arrow-key navigation</strong> between focusable
-          descendants</li>
-        <li><strong>Single tab stop</strong> — Tab enters the group,
-          arrows navigate within, Tab exits</li>
-        <li><strong>Focus memory</strong> — remembers which element had
-          focus when you return</li>
-        <li><strong>Wrapping</strong> — optional wrap-around at
-          boundaries</li>
-        <li><strong>Axis locking</strong> — restrict to horizontal
-          (<code>inline</code>) or vertical (<code>block</code>)</li>
-        <li><strong>Opt-out</strong> — exclude elements from the group
-          with <code>focusgroup="none"</code></li>
-      </ul>
+      <p>
+        It makes the group a single tab stop: Tab enters, arrow keys
+        navigate within, Tab exits. The browser tracks which element last
+        had focus and restores it on re-entry. Optional <code>wrap</code>,
+        <code>inline</code>, and <code>block</code> tokens control
+        boundary behavior and axis restriction.
+      </p>
+      <p>
+        The <code>focusgroup</code> attribute manages keyboard navigation
+        only. For elements with an explicit <code>role=</code> attribute or
+        non-generic native semantics (such as <code>&lt;ul&gt;</code> or
+        <code>&lt;nav&gt;</code>), the browser does not override or infer a
+        role. For plain <code>&lt;div&gt;</code> elements without an explicit
+        role, the behavior token's minimum role is inferred automatically
+        (e.g., <code>focusgroup="toolbar"</code> on a <code>&lt;div&gt;</code>
+        infers <code>role="toolbar"</code>). In either case, set
+        <code>role</code> attributes explicitly to keep authoring intent clear.
+      </p>
     </section>
 
     <section class="demo-section">
-      <h2 id="quick-demo-try-it-now">Quick Demo: Try It Now</h2>
+      <h2 id="quick-demo">Quick Demo</h2>
       <p>Click on the first button below, then use <kbd>←</kbd>
         <kbd>→</kbd> arrow keys to navigate. Press <kbd>Tab</kbd> to
         exit.
       </p>
       <div class="demo-container">
-        <div focusgroup="toolbar inline wrap" aria-label="Quick demo toolbar" class="toolbar-horizontal">
+        <div role="toolbar" focusgroup="toolbar wrap" aria-label="Quick demo toolbar" class="toolbar-horizontal">
           <button type="button">Bold</button>
           <button type="button">Italic</button>
           <button type="button">Underline</button>
@@ -70,39 +70,37 @@
           <button type="button">Link</button>
         </div>
       </div>
-      <div class="attr-label">focusgroup="toolbar inline wrap"</div>
+      <div class="attr-label">focusgroup="toolbar wrap"</div>
       <ul class="notice-list">
         <li>The entire toolbar is <strong>one tab stop</strong></li>
         <li>Left/Right arrows move focus between buttons</li>
         <li>Focus wraps from the last button back to the first (and
           vice versa)</li>
-        <li><strong>No JavaScript</strong> was used for focus
-          management</li>
       </ul>
     </section>
 
     <section class="demo-section">
       <h2 id="explore-the-demos">Explore the Demos</h2>
-      <p>Each demo page showcases a specific UI pattern with interactive
-        examples and source code.</p>
-      <nav aria-label="Explore the Demos">
-        <ul class="card-grid" focusgroup="listbox">
+      <nav aria-labelledby="explore-the-demos">
+        <p class="sr-only">Use arrow keys to navigate between demo cards.</p>
+        <!-- <ul> has non-generic native semantics, so the browser skips
+             role mapping and the element retains role="list". focusgroup
+             navigation (inline arrow keys) still activates. -->
+        <ul class="card-grid" focusgroup="toolbar wrap">
           <li>
             <a href="toolbar.html" class="card-link">
               <h3>Toolbar</h3>
               <p>Horizontal and vertical toolbars with arrow-key
                 navigation, entry points, and axis locking.</p>
-              <span class="attr-label">focusgroup="toolbar
-                inline"</span>
+              <span class="attr-label" aria-hidden="true">focusgroup="toolbar"</span>
             </a>
           </li>
           <li>
             <a href="tablist.html" class="card-link">
               <h3>Tablist</h3>
-              <p>Tab control with inline wrapping, no-memory for
+              <p>Tab control with inline wrapping, <code>nomemory</code> for
                 selected tab, and vertical variant.</p>
-              <span class="attr-label">focusgroup="tablist inline
-                wrap"</span>
+              <span class="attr-label" aria-hidden="true">focusgroup="tablist"</span>
             </a>
           </li>
           <li>
@@ -110,8 +108,7 @@
               <h3>Menu &amp; Menubar</h3>
               <p>Vertical menus and menubar with popover submenus
                 using nested focusgroups.</p>
-              <span class="attr-label">focusgroup="menu
-                block"</span>
+              <span class="attr-label" aria-hidden="true">focusgroup="menubar"</span>
             </a>
           </li>
           <li>
@@ -119,7 +116,7 @@
               <h3>Radio Group</h3>
               <p>Custom radio button groups with arrow-key
                 navigation, compared to native radios.</p>
-              <span class="attr-label">focusgroup="radiogroup"
+              <span class="attr-label" aria-hidden="true">focusgroup="radiogroup"
               </span>
             </a>
           </li>
@@ -128,7 +125,7 @@
               <h3>Listbox</h3>
               <p>Selectable list with vertical navigation and
                 selection management.</p>
-              <span class="attr-label">focusgroup="listbox
+              <span class="attr-label" aria-hidden="true">focusgroup="listbox
                 block"</span>
             </a>
           </li>
@@ -137,8 +134,7 @@
               <h3>Accordion</h3>
               <p>Accordion headers with block-axis navigation and
                 opt-out panels.</p>
-              <span class="attr-label">focusgroup="toolbar
-                block"</span>
+              <span class="attr-label" aria-hidden="true">focusgroup="toolbar block"</span>
             </a>
           </li>
           <li>
@@ -146,7 +142,7 @@
               <h3>Additional Concepts</h3>
               <p>Nested focusgroups, opt-out, deep descendants,
                 reading-flow, and feature detection.</p>
-              <span class="attr-label">focusgroup="none"</span>
+              <span class="attr-label" aria-hidden="true">focusgroup="none"</span>
             </a>
           </li>
         </ul>

--- a/focusgroup/listbox.html
+++ b/focusgroup/listbox.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Focusgroup: Listbox Pattern</title>
   <link rel="icon" type="image/png" href="https://edgestatic.azureedge.net/welcome/static/favicon.png">
@@ -41,47 +40,54 @@
       </div>
 
       <div class="demo-container">
-        <div focusgroup="listbox block" aria-label="Favorite fruit" class="listbox">
-          <div class="listbox-option selected" tabindex="0" aria-selected="true">Apple</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Banana</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Cherry</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Date</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Elderberry</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Fig</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Grape</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Honeydew</div>
+        <div role="listbox" focusgroup="listbox block" aria-label="Favorite fruit" aria-multiselectable="false" class="listbox">
+          <div role="option" class="listbox-option selected" tabindex="0" aria-selected="true">Apple</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Banana</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Cherry</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Date</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Elderberry</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Fig</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Grape</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Honeydew</div>
         </div>
       </div>
 
       <ul class="notice-list">
         <li>Up/Down arrows navigate between options</li>
         <li><kbd>Home</kbd> jumps to the first option, <kbd>End</kbd>
-          to the last (built into focusgroup)</li>
-        <li>The listbox is one tab stop — Tab enters, arrows navigate,
-          Tab exits</li>
-        <li>Selection state (<code>aria-selected</code>) is managed by
-          JavaScript — focusgroup handles navigation only</li>
+          to the last (built into focusgroup in supporting browsers;
+          JavaScript fallback may be needed otherwise)</li>
+        <li>The listbox is a single tab stop. Tab enters, arrows navigate, and Tab exits.</li>
+        <li>Selection state (<code>aria-selected</code>) is managed by JavaScript. focusgroup handles navigation only.</li>
+        <li><code>&lt;div role="option"&gt;</code> is not natively focusable.
+          Give every option <code>tabindex="0"</code> so the browser can
+          focus it. <code>focusgroup</code> collapses those tab stops into
+          one. No manual <code>tabindex="-1"</code> management needed.</li>
+        <li><code>listbox</code> has no default axis modifier. The explicit
+          <code>block</code> here activates Up/Down arrow navigation.
+          Without it, no axis would be active.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="listbox block"
-     aria-label="Favorite fruit"&gt;
-    &lt;div class="listbox-option selected" tabindex="0"
+        <pre><code>&lt;div role="listbox" focusgroup="listbox block"
+     aria-label="Favorite fruit"
+     aria-multiselectable="false"&gt;
+    &lt;div role="option" class="listbox-option selected" tabindex="0"
          aria-selected="true"&gt;Apple&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Banana&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Cherry&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Date&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Elderberry&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Fig&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Grape&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Honeydew&lt;/div&gt;
 &lt;/div&gt;</code></pre>
       </details>
@@ -98,16 +104,16 @@
 
       <div class="try-it">
         <strong>Try it:</strong> Navigate to "Mango" (last item), then
-        press <kbd>↓</kbd> — focus wraps to "Avocado".
+        press <kbd>↓</kbd> and focus wraps to "Avocado".
       </div>
 
       <div class="demo-container">
-        <div focusgroup="listbox block wrap" aria-label="Tropical fruits" class="listbox">
-          <div class="listbox-option selected" tabindex="0" aria-selected="true">Avocado</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Coconut</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Guava</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Kiwi</div>
-          <div class="listbox-option" tabindex="0" aria-selected="false">Mango</div>
+        <div role="listbox" focusgroup="listbox block wrap" aria-label="Tropical fruits" aria-multiselectable="false" class="listbox">
+          <div role="option" class="listbox-option selected" tabindex="0" aria-selected="true">Avocado</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Coconut</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Guava</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Kiwi</div>
+          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Mango</div>
         </div>
       </div>
 
@@ -117,21 +123,25 @@
         <li>Down from last → first; Up from first → last</li>
         <li>Without <code>wrap</code>, navigation stops at the
           boundaries</li>
+        <li>Unlike <code>menu</code> and <code>menubar</code> (which wrap by
+          default), <code>listbox</code> does not wrap by default. The
+          <code>wrap</code> token here is an explicit opt-in.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="listbox block wrap"
-     aria-label="Tropical fruits"&gt;
-    &lt;div class="listbox-option selected" tabindex="0"
+        <pre><code>&lt;div role="listbox" focusgroup="listbox block wrap"
+     aria-label="Tropical fruits"
+     aria-multiselectable="false"&gt;
+    &lt;div role="option" class="listbox-option selected" tabindex="0"
          aria-selected="true"&gt;Avocado&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Coconut&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Guava&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Kiwi&lt;/div&gt;
-    &lt;div class="listbox-option" tabindex="0"
+    &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Mango&lt;/div&gt;
 &lt;/div&gt;</code></pre>
       </details>

--- a/focusgroup/listbox.html
+++ b/focusgroup/listbox.html
@@ -55,8 +55,8 @@
       <ul class="notice-list">
         <li>Up/Down arrows navigate between options</li>
         <li><kbd>Home</kbd> jumps to the first option, <kbd>End</kbd>
-          to the last (built into focusgroup in supporting browsers;
-          JavaScript fallback may be needed otherwise)</li>
+          to the last. This is built into <code>focusgroup</code>;
+          add JavaScript handlers if your target browsers don't support it yet</li>
         <li>The listbox is a single tab stop. Tab enters, arrows navigate, and Tab exits.</li>
         <li>Selection state (<code>aria-selected</code>) is managed by JavaScript. focusgroup handles navigation only.</li>
         <li><code>&lt;div role="option"&gt;</code> is not natively focusable.

--- a/focusgroup/listbox.html
+++ b/focusgroup/listbox.html
@@ -39,15 +39,15 @@
       </div>
 
       <div class="demo-container">
-        <div role="listbox" focusgroup="listbox block nomemory" aria-label="Favorite fruit" aria-multiselectable="false" class="listbox">
-          <div role="option" class="listbox-option selected" tabindex="0" aria-selected="true" focusgroupstart>Apple</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Banana</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Cherry</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Date</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Elderberry</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Fig</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Grape</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Honeydew</div>
+        <div focusgroup="listbox block nomemory" aria-label="Favorite fruit" aria-multiselectable="false" class="listbox">
+          <div class="listbox-option selected" tabindex="0" aria-selected="true" focusgroupstart>Apple</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Banana</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Cherry</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Date</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Elderberry</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Fig</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Grape</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Honeydew</div>
         </div>
       </div>
 
@@ -64,7 +64,8 @@
           selection-follows-focus for single-select listboxes; add a
           <code>focus</code> event handler calling
           <code>select(item)</code> on each option for that behavior.</li>
-        <li><code>&lt;div role="option"&gt;</code> is not natively focusable.
+        <li><code>&lt;div&gt;</code> children are not natively focusable (the
+          <code>listbox</code> token infers <code>role="option"</code> on each).
           Give every option <code>tabindex="0"</code> so the browser can
           focus it. <code>focusgroup</code> collapses those tab stops into
           one. No manual <code>tabindex="-1"</code> management needed.</li>
@@ -75,24 +76,24 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="listbox" focusgroup="listbox block nomemory"
+        <pre><code>&lt;div focusgroup="listbox block nomemory"
      aria-label="Favorite fruit"
      aria-multiselectable="false" class="listbox"&gt;
-    &lt;div role="option" class="listbox-option selected" tabindex="0"
+    &lt;div class="listbox-option selected" tabindex="0"
          aria-selected="true" focusgroupstart&gt;Apple&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Banana&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Cherry&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Date&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Elderberry&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Fig&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Grape&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Honeydew&lt;/div&gt;
 &lt;/div&gt;</code></pre>
       </details>
@@ -113,12 +114,12 @@
       </div>
 
       <div class="demo-container">
-        <div role="listbox" focusgroup="listbox block wrap nomemory" aria-label="Tropical fruits" aria-multiselectable="false" class="listbox">
-          <div role="option" class="listbox-option selected" tabindex="0" aria-selected="true" focusgroupstart>Avocado</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Coconut</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Guava</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Kiwi</div>
-          <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Mango</div>
+        <div focusgroup="listbox block wrap nomemory" aria-label="Tropical fruits" aria-multiselectable="false" class="listbox">
+          <div class="listbox-option selected" tabindex="0" aria-selected="true" focusgroupstart>Avocado</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Coconut</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Guava</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Kiwi</div>
+          <div class="listbox-option" tabindex="0" aria-selected="false">Mango</div>
         </div>
       </div>
 
@@ -134,18 +135,18 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="listbox" focusgroup="listbox block wrap nomemory"
+        <pre><code>&lt;div focusgroup="listbox block wrap nomemory"
      aria-label="Tropical fruits"
      aria-multiselectable="false" class="listbox"&gt;
-    &lt;div role="option" class="listbox-option selected" tabindex="0"
+    &lt;div class="listbox-option selected" tabindex="0"
          aria-selected="true" focusgroupstart&gt;Avocado&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Coconut&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Guava&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Kiwi&lt;/div&gt;
-    &lt;div role="option" class="listbox-option" tabindex="0"
+    &lt;div class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Mango&lt;/div&gt;
 &lt;/div&gt;</code></pre>
       </details>

--- a/focusgroup/listbox.html
+++ b/focusgroup/listbox.html
@@ -30,18 +30,17 @@
         Click or press
         <kbd>Enter</kbd>/<kbd>Space</kbd> to select an item.
       </p>
-      <div class="attr-label">focusgroup="listbox block"</div>
+      <div class="attr-label">focusgroup="listbox block nomemory"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>↓</kbd> and <kbd>↑</kbd> to
         navigate. Press <kbd>Enter</kbd> or <kbd>Space</kbd> to
-        select an option. <kbd>Home</kbd> and <kbd>End</kbd> jump
-        to the first and last items.
+        select an option.
       </div>
 
       <div class="demo-container">
-        <div role="listbox" focusgroup="listbox block" aria-label="Favorite fruit" aria-multiselectable="false" class="listbox">
-          <div role="option" class="listbox-option selected" tabindex="0" aria-selected="true">Apple</div>
+        <div role="listbox" focusgroup="listbox block nomemory" aria-label="Favorite fruit" aria-multiselectable="false" class="listbox">
+          <div role="option" class="listbox-option selected" tabindex="0" aria-selected="true" focusgroupstart>Apple</div>
           <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Banana</div>
           <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Cherry</div>
           <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Date</div>
@@ -54,27 +53,33 @@
 
       <ul class="notice-list">
         <li>Up/Down arrows navigate between options</li>
-        <li><kbd>Home</kbd> jumps to the first option, <kbd>End</kbd>
-          to the last. This is built into <code>focusgroup</code>;
-          add JavaScript handlers if your target browsers don't support it yet</li>
+        <li><kbd>Home</kbd> and <kbd>End</kbd> are not built into
+          <code>focusgroup</code>. Add JavaScript handlers if your listbox
+          pattern requires them</li>
         <li>The listbox is a single tab stop. Tab enters, arrows navigate, and Tab exits.</li>
-        <li>Selection state (<code>aria-selected</code>) is managed by JavaScript. focusgroup handles navigation only.</li>
+        <li>Selection state (<code>aria-selected</code>) is managed by JavaScript.
+          <code>focusgroup</code> handles navigation only.</li>
+        <li>This demo uses "browse-then-confirm" selection (Enter or Space
+          to select after arrowing). The ARIA APG recommends
+          selection-follows-focus for single-select listboxes; add a
+          <code>focus</code> event handler calling
+          <code>select(item)</code> on each option for that behavior.</li>
         <li><code>&lt;div role="option"&gt;</code> is not natively focusable.
           Give every option <code>tabindex="0"</code> so the browser can
           focus it. <code>focusgroup</code> collapses those tab stops into
           one. No manual <code>tabindex="-1"</code> management needed.</li>
         <li><code>listbox</code> has no default axis modifier. The explicit
-          <code>block</code> here activates Up/Down arrow navigation.
+          <code>block</code> here applies Up/Down arrow navigation.
           Without it, no axis would be active.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="listbox" focusgroup="listbox block"
+        <pre><code>&lt;div role="listbox" focusgroup="listbox block nomemory"
      aria-label="Favorite fruit"
-     aria-multiselectable="false"&gt;
+     aria-multiselectable="false" class="listbox"&gt;
     &lt;div role="option" class="listbox-option selected" tabindex="0"
-         aria-selected="true"&gt;Apple&lt;/div&gt;
+         aria-selected="true" focusgroupstart&gt;Apple&lt;/div&gt;
     &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Banana&lt;/div&gt;
     &lt;div role="option" class="listbox-option" tabindex="0"
@@ -98,9 +103,9 @@
     <!-- ============================================================ -->
     <section class="demo-section">
       <h2 id="listbox-with-wrapping">Listbox with Wrapping</h2>
-      <p>Adding <code>wrap</code> allows navigation to wrap from the last
-        item back to the first (and vice versa).</p>
-      <div class="attr-label">focusgroup="listbox block wrap"</div>
+      <p>With <code>wrap</code>, navigation continues from the last item
+        back to the first (and vice versa).</p>
+      <div class="attr-label">focusgroup="listbox block wrap nomemory"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Navigate to "Mango" (last item), then
@@ -108,8 +113,8 @@
       </div>
 
       <div class="demo-container">
-        <div role="listbox" focusgroup="listbox block wrap" aria-label="Tropical fruits" aria-multiselectable="false" class="listbox">
-          <div role="option" class="listbox-option selected" tabindex="0" aria-selected="true">Avocado</div>
+        <div role="listbox" focusgroup="listbox block wrap nomemory" aria-label="Tropical fruits" aria-multiselectable="false" class="listbox">
+          <div role="option" class="listbox-option selected" tabindex="0" aria-selected="true" focusgroupstart>Avocado</div>
           <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Coconut</div>
           <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Guava</div>
           <div role="option" class="listbox-option" tabindex="0" aria-selected="false">Kiwi</div>
@@ -118,8 +123,7 @@
       </div>
 
       <ul class="notice-list">
-        <li><code>wrap</code> enables circular navigation at
-          boundaries</li>
+        <li><code>wrap</code> makes navigation circular at boundaries</li>
         <li>Down from last → first; Up from first → last</li>
         <li>Without <code>wrap</code>, navigation stops at the
           boundaries</li>
@@ -130,11 +134,11 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="listbox" focusgroup="listbox block wrap"
+        <pre><code>&lt;div role="listbox" focusgroup="listbox block wrap nomemory"
      aria-label="Tropical fruits"
-     aria-multiselectable="false"&gt;
+     aria-multiselectable="false" class="listbox"&gt;
     &lt;div role="option" class="listbox-option selected" tabindex="0"
-         aria-selected="true"&gt;Avocado&lt;/div&gt;
+         aria-selected="true" focusgroupstart&gt;Avocado&lt;/div&gt;
     &lt;div role="option" class="listbox-option" tabindex="0"
          aria-selected="false"&gt;Coconut&lt;/div&gt;
     &lt;div role="option" class="listbox-option" tabindex="0"

--- a/focusgroup/listbox.js
+++ b/focusgroup/listbox.js
@@ -1,9 +1,9 @@
 /* ============================================================
-   Focusgroup Demo — Listbox
+   Focusgroup Demo - Listbox
    ============================================================
    focusgroup handles arrow-key navigation between options.
    This file handles the remaining application logic:
-   - Toggling aria-selected so exactly one option is selected
+   - Setting aria-selected so exactly one option is selected
      (click or Enter/Space to confirm)
 
    Requires shared.js to be loaded first.
@@ -17,7 +17,16 @@
       '[focusgroup~="listbox"]',
       ".listbox-option",
       "aria-selected",
-      "selected"
+      "selected",
+      function (target, items) {
+        items.forEach(function (item) {
+          if (item === target) {
+            item.setAttribute("focusgroupstart", "");
+          } else {
+            item.removeAttribute("focusgroupstart");
+          }
+        });
+      }
     );
   }
 

--- a/focusgroup/menu.html
+++ b/focusgroup/menu.html
@@ -85,40 +85,36 @@
       <div class="demo-container">
         <ul role="menubar" focusgroup="menubar" aria-label="Application Menu" class="menubar">
           <li role="none">
-            <button role="menuitem" type="button" class="menubar-item" style="anchor-name: --file-trigger"
+            <button role="menuitem" type="button" class="menubar-item"
               aria-haspopup="menu" aria-expanded="false" popovertarget="filemenu">File</button>
-            <ul role="menu" focusgroup="menu" id="filemenu" popover aria-label="File submenu" class="submenu"
-              style="position-anchor: --file-trigger">
+            <ul role="menu" focusgroup="menu" id="filemenu" popover aria-label="File submenu" class="submenu">
               <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>New</button></li>
               <li role="none"><button role="menuitem" type="button" class="submenu-item">Open</button></li>
               <li role="none"><button role="menuitem" type="button" class="submenu-item">Save</button></li>
             </ul>
           </li>
           <li role="none">
-            <button role="menuitem" type="button" class="menubar-item" style="anchor-name: --edit-trigger"
+            <button role="menuitem" type="button" class="menubar-item"
               aria-haspopup="menu" aria-expanded="false" popovertarget="editmenu">Edit</button>
-            <ul role="menu" focusgroup="menu" id="editmenu" popover aria-label="Edit submenu" class="submenu"
-              style="position-anchor: --edit-trigger">
+            <ul role="menu" focusgroup="menu" id="editmenu" popover aria-label="Edit submenu" class="submenu">
               <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>Cut</button></li>
               <li role="none"><button role="menuitem" type="button" class="submenu-item">Copy</button></li>
               <li role="none"><button role="menuitem" type="button" class="submenu-item">Paste</button></li>
             </ul>
           </li>
           <li role="none">
-            <button role="menuitem" type="button" class="menubar-item" style="anchor-name: --view-trigger"
+            <button role="menuitem" type="button" class="menubar-item"
               aria-haspopup="menu" aria-expanded="false" popovertarget="viewmenu">View</button>
-            <ul role="menu" focusgroup="menu" id="viewmenu" popover aria-label="View submenu" class="submenu"
-              style="position-anchor: --view-trigger">
+            <ul role="menu" focusgroup="menu" id="viewmenu" popover aria-label="View submenu" class="submenu">
               <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>Zoom In</button></li>
               <li role="none"><button role="menuitem" type="button" class="submenu-item">Zoom Out</button></li>
               <li role="none"><button role="menuitem" type="button" class="submenu-item">Full Screen</button></li>
             </ul>
           </li>
           <li role="none">
-            <button role="menuitem" type="button" class="menubar-item" style="anchor-name: --help-trigger"
+            <button role="menuitem" type="button" class="menubar-item"
               aria-haspopup="menu" aria-expanded="false" popovertarget="helpmenu">Help</button>
-            <ul role="menu" focusgroup="menu" id="helpmenu" popover aria-label="Help submenu" class="submenu"
-              style="position-anchor: --help-trigger">
+            <ul role="menu" focusgroup="menu" id="helpmenu" popover aria-label="Help submenu" class="submenu">
               <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>Documentation</button></li>
               <li role="none"><button role="menuitem" type="button" class="submenu-item">About</button></li>
             </ul>
@@ -144,12 +140,11 @@
      aria-label="Application Menu" class="menubar"&gt;
     &lt;li role="none"&gt;
         &lt;button role="menuitem" type="button" class="menubar-item"
-             style="anchor-name: --file-trigger"
+            
              aria-haspopup="menu" aria-expanded="false"
              popovertarget="filemenu"&gt;File&lt;/button&gt;
         &lt;ul role="menu" focusgroup="menu"
-             id="filemenu" popover aria-label="File submenu" class="submenu"
-             style="position-anchor: --file-trigger"&gt;
+             id="filemenu" popover aria-label="File submenu" class="submenu"&gt;
             &lt;li role="none"&gt;&lt;button role="menuitem" type="button" class="submenu-item"
                  autofocus&gt;New&lt;/button&gt;&lt;/li&gt;
             &lt;li role="none"&gt;&lt;button role="menuitem" type="button" class="submenu-item"&gt;Open&lt;/button&gt;&lt;/li&gt;

--- a/focusgroup/menu.html
+++ b/focusgroup/menu.html
@@ -44,7 +44,6 @@
       <ul class="notice-list">
         <li><code>menu</code> defaults to <code>block wrap</code> (Up/Down with wrapping). This demo uses those defaults.</li>
         <li>The menu is a single tab stop. Arrow keys navigate within.</li>
-        <li>The <code>menu</code> behavior token maps <code>role="menu"</code> on a generic container (like Demo 1's <code>&lt;div&gt;</code>) and infers <code>role="menuitem"</code> on child <code>&lt;button&gt;</code> elements. No explicit <code>role</code> is needed on those elements. In Demo 2, the <code>&lt;ul&gt;</code> and <code>&lt;li&gt;</code> elements are non-generic, so the behavior token's container mapping is skipped. Explicit <code>role="menubar"</code>, <code>role="menu"</code>, and <code>role="none"</code> are needed to override their native list semantics. The menubar trigger buttons use explicit <code>role="menuitem"</code> because popup buttons (<code>popovertarget</code> + <code>aria-haspopup</code>) are not considered for role inference due to a Blink bug. Submenu buttons without popups get <code>role="menuitem"</code> inferred by the token.</li>
         <li>No JavaScript needed for navigation</li>
       </ul>
 

--- a/focusgroup/menu.html
+++ b/focusgroup/menu.html
@@ -25,7 +25,7 @@
     <section class="demo-section">
       <h2 id="simple-vertical-menu">Simple Vertical Menu</h2>
       <p>A basic vertical menu with Up/Down arrow navigation.</p>
-      <div class="attr-label">focusgroup="menu nowrap"</div>
+      <div class="attr-label">focusgroup="menu"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Tab to (or click) a menu item, then use
@@ -33,30 +33,29 @@
       </div>
 
       <div class="demo-container">
-        <div role="menu" focusgroup="menu nowrap" aria-label="File actions" class="menu-vertical">
-          <button role="menuitem" type="button" class="menu-item">New</button>
-          <button role="menuitem" type="button" class="menu-item">Open…</button>
-          <button role="menuitem" type="button" class="menu-item">Save</button>
-          <button role="menuitem" type="button" class="menu-item">Exit</button>
+        <div focusgroup="menu" aria-label="File actions" class="menu-vertical">
+          <button type="button" class="menu-item">New</button>
+          <button type="button" class="menu-item">Open…</button>
+          <button type="button" class="menu-item">Save</button>
+          <button type="button" class="menu-item">Exit</button>
         </div>
       </div>
 
       <ul class="notice-list">
-        <li><code>menu</code> defaults to <code>block wrap</code> (Up/Down with wrapping). No explicit modifiers are needed.</li>
-        <li><code>nowrap</code> disables the default wrapping behavior</li>
+        <li><code>menu</code> defaults to <code>block wrap</code> (Up/Down with wrapping). This demo uses those defaults.</li>
         <li>The menu is a single tab stop. Arrow keys navigate within.</li>
-        <li>Each <code>&lt;button&gt;</code> has an implicit role of <code>"button"</code>. Inside <code>role="menu"</code>, children must be <code>role="menuitem"</code> (or <code>role="menuitemcheckbox"</code> / <code>role="menuitemradio"</code>). When the container has an explicit <code>role</code>, the behavior token's minimum-role mapping is skipped. These demos set roles explicitly for clarity.</li>
+        <li>The <code>menu</code> behavior token maps <code>role="menu"</code> on a generic container (like this <code>&lt;div&gt;</code>) and infers <code>role="menuitem"</code> on child <code>&lt;button&gt;</code> elements, so no explicit role attributes are needed.</li>
         <li>No JavaScript needed for navigation</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="menu" focusgroup="menu nowrap" aria-label="File actions"
+        <pre><code>&lt;div focusgroup="menu" aria-label="File actions"
      class="menu-vertical"&gt;
-    &lt;button role="menuitem" type="button" class="menu-item"&gt;New&lt;/button&gt;
-    &lt;button role="menuitem" type="button" class="menu-item"&gt;Open…&lt;/button&gt;
-    &lt;button role="menuitem" type="button" class="menu-item"&gt;Save&lt;/button&gt;
-    &lt;button role="menuitem" type="button" class="menu-item"&gt;Exit&lt;/button&gt;
+    &lt;button type="button" class="menu-item"&gt;New&lt;/button&gt;
+    &lt;button type="button" class="menu-item"&gt;Open…&lt;/button&gt;
+    &lt;button type="button" class="menu-item"&gt;Save&lt;/button&gt;
+    &lt;button type="button" class="menu-item"&gt;Exit&lt;/button&gt;
 &lt;/div&gt;</code></pre>
       </details>
     </section>

--- a/focusgroup/menu.html
+++ b/focusgroup/menu.html
@@ -28,7 +28,7 @@
       <div class="attr-label">focusgroup="menu nowrap"</div>
 
       <div class="try-it">
-        <strong>Try it:</strong> Click a menu item, then use
+        <strong>Try it:</strong> Tab to (or click) a menu item, then use
         <kbd>↓</kbd> and <kbd>↑</kbd> to navigate between items.
       </div>
 
@@ -42,17 +42,17 @@
       </div>
 
       <ul class="notice-list">
-        <li><code>menu</code> defaults to block axis (Up/Down arrows). No explicit <code>block</code> modifier is needed.</li>
+        <li><code>menu</code> defaults to <code>block wrap</code> (Up/Down with wrapping). No explicit modifiers are needed.</li>
         <li><code>nowrap</code> disables the default wrapping behavior</li>
         <li>The menu is a single tab stop. Arrow keys navigate within.</li>
-        <li>Each <code>&lt;button&gt;</code> needs an explicit <code>role="menuitem"</code> here because the container has an explicit <code>role="menu"</code>. The browser skips child role inference when an explicit container role is present. If you omit <code>role="menu"</code> from the container, the browser infers it and also infers <code>role="menuitem"</code> on each <code>&lt;button&gt;</code> child automatically.</li>
+        <li>Each <code>&lt;button&gt;</code> has an implicit role of <code>"button"</code>. Inside <code>role="menu"</code>, children must be <code>role="menuitem"</code> (or <code>role="menuitemcheckbox"</code> / <code>role="menuitemradio"</code>). When the container has an explicit <code>role</code>, the behavior token's minimum-role mapping is skipped. These demos set roles explicitly for clarity.</li>
         <li>No JavaScript needed for navigation</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="menu" focusgroup="menu nowrap" aria-label="File
-     actions"&gt;
+        <pre><code>&lt;div role="menu" focusgroup="menu nowrap" aria-label="File actions"
+     class="menu-vertical"&gt;
     &lt;button role="menuitem" type="button" class="menu-item"&gt;New&lt;/button&gt;
     &lt;button role="menuitem" type="button" class="menu-item"&gt;Open…&lt;/button&gt;
     &lt;button role="menuitem" type="button" class="menu-item"&gt;Save&lt;/button&gt;
@@ -76,9 +76,11 @@
       <div class="attr-label">focusgroup="menubar"</div>
 
       <div class="try-it">
-        <strong>Try it:</strong> Use <kbd>→</kbd> <kbd>←</kbd> on the
-        menubar. Click a top-level item to open its submenu, then
-        use <kbd>↓</kbd> <kbd>↑</kbd> inside.
+        <strong>Try it:</strong> Tab to the menubar. Use <kbd>→</kbd>
+        <kbd>←</kbd> to move between top-level items. Press
+        <kbd>Enter</kbd> or <kbd>Space</kbd> to open a submenu, then use
+        <kbd>↓</kbd> <kbd>↑</kbd> inside. Press <kbd>Escape</kbd> to
+        close and return focus to the menu bar item.
       </div>
 
       <div class="demo-container">
@@ -140,25 +142,23 @@
       <details class="source-code">
         <summary>View source</summary>
         <pre><code>&lt;ul role="menubar" focusgroup="menubar"
-     aria-label="Application Menu"&gt;
+     aria-label="Application Menu" class="menubar"&gt;
     &lt;li role="none"&gt;
-        &lt;button role="menuitem" type="button"
+        &lt;button role="menuitem" type="button" class="menubar-item"
              style="anchor-name: --file-trigger"
              aria-haspopup="menu" aria-expanded="false"
              popovertarget="filemenu"&gt;File&lt;/button&gt;
         &lt;ul role="menu" focusgroup="menu"
-             id="filemenu" aria-label="File submenu"
-             popover
+             id="filemenu" popover aria-label="File submenu" class="submenu"
              style="position-anchor: --file-trigger"&gt;
-            &lt;li role="none"&gt;&lt;button role="menuitem" type="button"
+            &lt;li role="none"&gt;&lt;button role="menuitem" type="button" class="submenu-item"
                  autofocus&gt;New&lt;/button&gt;&lt;/li&gt;
-            &lt;li role="none"&gt;&lt;button role="menuitem" type="button"&gt;Open&lt;/button&gt;&lt;/li&gt;
-            &lt;li role="none"&gt;&lt;button role="menuitem" type="button"&gt;Save&lt;/button&gt;&lt;/li&gt;
+            &lt;li role="none"&gt;&lt;button role="menuitem" type="button" class="submenu-item"&gt;Open&lt;/button&gt;&lt;/li&gt;
+            &lt;li role="none"&gt;&lt;button role="menuitem" type="button" class="submenu-item"&gt;Save&lt;/button&gt;&lt;/li&gt;
         &lt;/ul&gt;
     &lt;/li&gt;
     &lt;!-- More menu items... --&gt;
-&lt;/ul&gt;
-&lt;!-- JavaScript manages aria-expanded on popover toggle --&gt;</code></pre>
+&lt;/ul&gt;</code></pre>
       </details>
     </section>
 
@@ -180,7 +180,7 @@
         <li>Up/Down arrows navigate within an open
           <strong>submenu</strong> (block axis)
         </li>
-        <li>Tab moves focus out of both the submenu and the menubar</li>
+        <li>Tab moves focus out of the submenu and continues through the normal tab order</li>
       </ul>
     </section>
 

--- a/focusgroup/menu.html
+++ b/focusgroup/menu.html
@@ -45,7 +45,7 @@
         <li><code>menu</code> defaults to block axis (Up/Down arrows). No explicit <code>block</code> modifier is needed.</li>
         <li><code>nowrap</code> disables the default wrapping behavior</li>
         <li>The menu is a single tab stop. Arrow keys navigate within.</li>
-        <li>Each <code>&lt;button&gt;</code> needs an explicit <code>role="menuitem"</code>. Because this container already has an explicit <code>role="menu"</code>, the browser skips child role inference. Without the explicit container role, a <code>&lt;button&gt;</code> inside <code>focusgroup="menu"</code> would receive an inferred <code>role="menuitem"</code> automatically.</li>
+        <li>Each <code>&lt;button&gt;</code> needs an explicit <code>role="menuitem"</code> here because the container has an explicit <code>role="menu"</code>. The browser skips child role inference when an explicit container role is present. If you omit <code>role="menu"</code> from the container, the browser infers it and also infers <code>role="menuitem"</code> on each <code>&lt;button&gt;</code> child automatically.</li>
         <li>No JavaScript needed for navigation</li>
       </ul>
 
@@ -132,9 +132,9 @@
           They don't interfere with each other.</li>
         <li>The <code>popover</code> attribute handles submenu
           visibility</li>
-        <li>The focusgroup spec leaves the orthogonal axis (Up/Down on
-          the menubar) free for authors. Add JS to open/close submenus
-          with those keys as a progressive enhancement.</li>
+        <li>The spec leaves the orthogonal axis (Up/Down on the menubar)
+          free for authors. JavaScript can open/close submenus with
+          those keys as a progressive enhancement.</li>
       </ul>
 
       <details class="source-code">
@@ -202,8 +202,9 @@
         if (e.key !== "Escape") return;
         var openPopover = document.querySelector("[popover]:popover-open");
         if (!openPopover) return;
-        var triggerId = openPopover.id;
-        var trigger = document.querySelector("[popovertarget='" + triggerId + "']");
+        e.preventDefault();
+        var popoverId = openPopover.id;
+        var trigger = document.querySelector("[popovertarget='" + popoverId + "']");
         openPopover.hidePopover();
         if (trigger) trigger.focus();
       });

--- a/focusgroup/menu.html
+++ b/focusgroup/menu.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Focusgroup: Menu &amp; Menubar Pattern</title>
   <link rel="icon" type="image/png" href="https://edgestatic.azureedge.net/welcome/static/favicon.png">
@@ -26,7 +25,7 @@
     <section class="demo-section">
       <h2 id="simple-vertical-menu">Simple Vertical Menu</h2>
       <p>A basic vertical menu with Up/Down arrow navigation.</p>
-      <div class="attr-label">focusgroup="menu block"</div>
+      <div class="attr-label">focusgroup="menu nowrap"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Click a menu item, then use
@@ -34,29 +33,30 @@
       </div>
 
       <div class="demo-container">
-        <div focusgroup="menu block" aria-label="File actions" class="menu-vertical">
-          <div class="menu-item" tabindex="0">New</div>
-          <div class="menu-item" tabindex="0">Open…</div>
-          <div class="menu-item" tabindex="0">Save</div>
-          <div class="menu-item" tabindex="0">Exit</div>
+        <div role="menu" focusgroup="menu nowrap" aria-label="File actions" class="menu-vertical">
+          <button role="menuitem" type="button" class="menu-item">New</button>
+          <button role="menuitem" type="button" class="menu-item">Open…</button>
+          <button role="menuitem" type="button" class="menu-item">Save</button>
+          <button role="menuitem" type="button" class="menu-item">Exit</button>
         </div>
       </div>
 
       <ul class="notice-list">
-        <li><code>block</code> restricts to Up/Down arrows (vertical
-          menu)</li>
-        <li>The menu is one tab stop — arrow keys navigate within</li>
+        <li><code>menu</code> defaults to block axis (Up/Down arrows). No explicit <code>block</code> modifier is needed.</li>
+        <li><code>nowrap</code> disables the default wrapping behavior</li>
+        <li>The menu is a single tab stop. Arrow keys navigate within.</li>
+        <li>Each <code>&lt;button&gt;</code> needs an explicit <code>role="menuitem"</code>. Because this container already has an explicit <code>role="menu"</code>, the browser skips child role inference. Without the explicit container role, a <code>&lt;button&gt;</code> inside <code>focusgroup="menu"</code> would receive an inferred <code>role="menuitem"</code> automatically.</li>
         <li>No JavaScript needed for navigation</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="menu block" aria-label="File
+        <pre><code>&lt;div role="menu" focusgroup="menu nowrap" aria-label="File
      actions"&gt;
-    &lt;div class="menu-item" tabindex="0"&gt;New&lt;/div&gt;
-    &lt;div class="menu-item" tabindex="0"&gt;Open…&lt;/div&gt;
-    &lt;div class="menu-item" tabindex="0"&gt;Save&lt;/div&gt;
-    &lt;div class="menu-item" tabindex="0"&gt;Exit&lt;/div&gt;
+    &lt;button role="menuitem" type="button" class="menu-item"&gt;New&lt;/button&gt;
+    &lt;button role="menuitem" type="button" class="menu-item"&gt;Open…&lt;/button&gt;
+    &lt;button role="menuitem" type="button" class="menu-item"&gt;Save&lt;/button&gt;
+    &lt;button role="menuitem" type="button" class="menu-item"&gt;Exit&lt;/button&gt;
 &lt;/div&gt;</code></pre>
       </details>
     </section>
@@ -67,13 +67,13 @@
     <section class="demo-section">
       <h2 id="menubar-with-popover-submenus">Menubar with Popover Submenus</h2>
       <p>
-        A horizontal menubar using <code>inline</code> for Left/Right
+        A horizontal menubar. <code>menubar</code> defaults to inline (Left/Right)
         navigation between top-level items.
-        Each submenu is a separate <code>focusgroup</code> with
-        <code>block</code> for Up/Down navigation.
+        Each submenu uses a separate <code>focusgroup="menu"</code> which defaults
+        to block (Up/Down) navigation.
         Submenus use the <code>popover</code> attribute for display.
       </p>
-      <div class="attr-label">focusgroup="menubar inline wrap"</div>
+      <div class="attr-label">focusgroup="menubar"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>→</kbd> <kbd>←</kbd> on the
@@ -82,81 +82,83 @@
       </div>
 
       <div class="demo-container">
-        <ul role="menubar" focusgroup="menubar inline wrap" aria-label="Application Menu" class="menubar">
+        <ul role="menubar" focusgroup="menubar" aria-label="Application Menu" class="menubar">
           <li role="none">
             <button role="menuitem" type="button" class="menubar-item" style="anchor-name: --file-trigger"
-              popovertarget="filemenu">File</button>
-            <ul role="menu" focusgroup="menu block wrap" id="filemenu" popover class="submenu"
+              aria-haspopup="menu" aria-expanded="false" popovertarget="filemenu">File</button>
+            <ul role="menu" focusgroup="menu" id="filemenu" popover aria-label="File submenu" class="submenu"
               style="position-anchor: --file-trigger">
-              <li role="none"><button role="menuitem" class="submenu-item" autofocus>New</button></li>
-              <li role="none"><button role="menuitem" class="submenu-item">Open</button></li>
-              <li role="none"><button role="menuitem" class="submenu-item">Save</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>New</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item">Open</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item">Save</button></li>
             </ul>
           </li>
           <li role="none">
             <button role="menuitem" type="button" class="menubar-item" style="anchor-name: --edit-trigger"
-              popovertarget="editmenu">Edit</button>
-            <ul role="menu" focusgroup="menu block wrap" id="editmenu" popover class="submenu"
+              aria-haspopup="menu" aria-expanded="false" popovertarget="editmenu">Edit</button>
+            <ul role="menu" focusgroup="menu" id="editmenu" popover aria-label="Edit submenu" class="submenu"
               style="position-anchor: --edit-trigger">
-              <li role="none"><button role="menuitem" class="submenu-item" autofocus>Cut</button></li>
-              <li role="none"><button role="menuitem" class="submenu-item">Copy</button></li>
-              <li role="none"><button role="menuitem" class="submenu-item">Paste</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>Cut</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item">Copy</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item">Paste</button></li>
             </ul>
           </li>
           <li role="none">
             <button role="menuitem" type="button" class="menubar-item" style="anchor-name: --view-trigger"
-              popovertarget="viewmenu">View</button>
-            <ul role="menu" focusgroup="menu block wrap" id="viewmenu" popover class="submenu"
+              aria-haspopup="menu" aria-expanded="false" popovertarget="viewmenu">View</button>
+            <ul role="menu" focusgroup="menu" id="viewmenu" popover aria-label="View submenu" class="submenu"
               style="position-anchor: --view-trigger">
-              <li role="none"><button role="menuitem" class="submenu-item" autofocus>Zoom In</button></li>
-              <li role="none"><button role="menuitem" class="submenu-item">Zoom Out</button></li>
-              <li role="none"><button role="menuitem" class="submenu-item">Full Screen</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>Zoom In</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item">Zoom Out</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item">Full Screen</button></li>
             </ul>
           </li>
           <li role="none">
             <button role="menuitem" type="button" class="menubar-item" style="anchor-name: --help-trigger"
-              popovertarget="helpmenu">Help</button>
-            <ul role="menu" focusgroup="menu block wrap" id="helpmenu" popover class="submenu"
+              aria-haspopup="menu" aria-expanded="false" popovertarget="helpmenu">Help</button>
+            <ul role="menu" focusgroup="menu" id="helpmenu" popover aria-label="Help submenu" class="submenu"
               style="position-anchor: --help-trigger">
-              <li role="none"><button role="menuitem" class="submenu-item" autofocus>Documentation</button></li>
-              <li role="none"><button role="menuitem" class="submenu-item">About</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>Documentation</button></li>
+              <li role="none"><button role="menuitem" type="button" class="submenu-item">About</button></li>
             </ul>
           </li>
         </ul>
       </div>
 
       <ul class="notice-list">
-        <li>The menubar uses <code>inline</code> (Left/Right), each
-          submenu uses <code>block</code> (Up/Down)</li>
-        <li>Nested focusgroups are <strong>independent scopes</strong>
-          — they don't interfere with each other</li>
+        <li><code>menubar</code> defaults to <code>inline wrap</code> (Left/Right with wrapping). No explicit modifiers are needed.</li>
+        <li><code>menu</code> defaults to <code>block wrap</code> (Up/Down with wrapping). No explicit modifiers are needed.</li>
+        <li>Nested focusgroups are <strong>independent scopes</strong>.
+          They don't interfere with each other.</li>
         <li>The <code>popover</code> attribute handles submenu
           visibility</li>
-        <li>The orthogonal axis (Up/Down on the menubar) is free for
-          authors to use for opening/closing menus via JS</li>
+        <li>The focusgroup spec leaves the orthogonal axis (Up/Down on
+          the menubar) free for authors. Add JS to open/close submenus
+          with those keys as a progressive enhancement.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;ul role="menubar" focusgroup="menubar inline
-     wrap" aria-label="Application Menu"&gt;
+        <pre><code>&lt;ul role="menubar" focusgroup="menubar"
+     aria-label="Application Menu"&gt;
     &lt;li role="none"&gt;
         &lt;button role="menuitem" type="button"
              style="anchor-name: --file-trigger"
+             aria-haspopup="menu" aria-expanded="false"
              popovertarget="filemenu"&gt;File&lt;/button&gt;
-        &lt;ul role="menu" focusgroup="menu block wrap"
-             id="filemenu" popover
+        &lt;ul role="menu" focusgroup="menu"
+             id="filemenu" aria-label="File submenu"
+             popover
              style="position-anchor: --file-trigger"&gt;
-            &lt;li role="none"&gt;&lt;button role="menuitem"
+            &lt;li role="none"&gt;&lt;button role="menuitem" type="button"
                  autofocus&gt;New&lt;/button&gt;&lt;/li&gt;
-            &lt;li role="none"&gt;&lt;button role="menuitem"
-                 &gt;Open&lt;/button&gt;&lt;/li&gt;
-            &lt;li role="none"&gt;&lt;button role="menuitem"
-                 &gt;Save&lt;/button&gt;&lt;/li&gt;
+            &lt;li role="none"&gt;&lt;button role="menuitem" type="button"&gt;Open&lt;/button&gt;&lt;/li&gt;
+            &lt;li role="none"&gt;&lt;button role="menuitem" type="button"&gt;Save&lt;/button&gt;&lt;/li&gt;
         &lt;/ul&gt;
     &lt;/li&gt;
     &lt;!-- More menu items... --&gt;
-&lt;/ul&gt;</code></pre>
+&lt;/ul&gt;
+&lt;!-- JavaScript manages aria-expanded on popover toggle --&gt;</code></pre>
       </details>
     </section>
 
@@ -185,6 +187,28 @@
   </main>
 
   <script src="shared.js"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      document.querySelectorAll("[popovertarget]").forEach(function (trigger) {
+        var popoverId = trigger.getAttribute("popovertarget");
+        var popover = document.getElementById(popoverId);
+        if (!popover) return;
+        popover.addEventListener("toggle", function (e) {
+          trigger.setAttribute("aria-expanded", e.newState === "open" ? "true" : "false");
+        });
+      });
+
+      document.addEventListener("keydown", function (e) {
+        if (e.key !== "Escape") return;
+        var openPopover = document.querySelector("[popover]:popover-open");
+        if (!openPopover) return;
+        var triggerId = openPopover.id;
+        var trigger = document.querySelector("[popovertarget='" + triggerId + "']");
+        openPopover.hidePopover();
+        if (trigger) trigger.focus();
+      });
+    });
+  </script>
 </body>
 
 </html>

--- a/focusgroup/menu.html
+++ b/focusgroup/menu.html
@@ -44,7 +44,7 @@
       <ul class="notice-list">
         <li><code>menu</code> defaults to <code>block wrap</code> (Up/Down with wrapping). This demo uses those defaults.</li>
         <li>The menu is a single tab stop. Arrow keys navigate within.</li>
-        <li>The <code>menu</code> behavior token maps <code>role="menu"</code> on a generic container (like this <code>&lt;div&gt;</code>) and infers <code>role="menuitem"</code> on child <code>&lt;button&gt;</code> elements, so no explicit role attributes are needed.</li>
+        <li>The <code>menu</code> behavior token maps <code>role="menu"</code> on a generic container (like Demo 1's <code>&lt;div&gt;</code>) and infers <code>role="menuitem"</code> on child <code>&lt;button&gt;</code> elements. No explicit <code>role</code> is needed on those elements. In Demo 2, the <code>&lt;ul&gt;</code> and <code>&lt;li&gt;</code> elements are non-generic, so the behavior token's container mapping is skipped. Explicit <code>role="menubar"</code>, <code>role="menu"</code>, and <code>role="none"</code> are needed to override their native list semantics. The menubar trigger buttons use explicit <code>role="menuitem"</code> because popup buttons (<code>popovertarget</code> + <code>aria-haspopup</code>) are not considered for role inference due to a Blink bug. Submenu buttons without popups get <code>role="menuitem"</code> inferred by the token.</li>
         <li>No JavaScript needed for navigation</li>
       </ul>
 
@@ -88,35 +88,35 @@
             <button role="menuitem" type="button" class="menubar-item"
               aria-haspopup="menu" aria-expanded="false" popovertarget="filemenu">File</button>
             <ul role="menu" focusgroup="menu" id="filemenu" popover aria-label="File submenu" class="submenu">
-              <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>New</button></li>
-              <li role="none"><button role="menuitem" type="button" class="submenu-item">Open</button></li>
-              <li role="none"><button role="menuitem" type="button" class="submenu-item">Save</button></li>
+              <li role="none"><button type="button" class="submenu-item" autofocus>New</button></li>
+              <li role="none"><button type="button" class="submenu-item">Open</button></li>
+              <li role="none"><button type="button" class="submenu-item">Save</button></li>
             </ul>
           </li>
           <li role="none">
             <button role="menuitem" type="button" class="menubar-item"
               aria-haspopup="menu" aria-expanded="false" popovertarget="editmenu">Edit</button>
             <ul role="menu" focusgroup="menu" id="editmenu" popover aria-label="Edit submenu" class="submenu">
-              <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>Cut</button></li>
-              <li role="none"><button role="menuitem" type="button" class="submenu-item">Copy</button></li>
-              <li role="none"><button role="menuitem" type="button" class="submenu-item">Paste</button></li>
+              <li role="none"><button type="button" class="submenu-item" autofocus>Cut</button></li>
+              <li role="none"><button type="button" class="submenu-item">Copy</button></li>
+              <li role="none"><button type="button" class="submenu-item">Paste</button></li>
             </ul>
           </li>
           <li role="none">
             <button role="menuitem" type="button" class="menubar-item"
               aria-haspopup="menu" aria-expanded="false" popovertarget="viewmenu">View</button>
             <ul role="menu" focusgroup="menu" id="viewmenu" popover aria-label="View submenu" class="submenu">
-              <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>Zoom In</button></li>
-              <li role="none"><button role="menuitem" type="button" class="submenu-item">Zoom Out</button></li>
-              <li role="none"><button role="menuitem" type="button" class="submenu-item">Full Screen</button></li>
+              <li role="none"><button type="button" class="submenu-item" autofocus>Zoom In</button></li>
+              <li role="none"><button type="button" class="submenu-item">Zoom Out</button></li>
+              <li role="none"><button type="button" class="submenu-item">Full Screen</button></li>
             </ul>
           </li>
           <li role="none">
             <button role="menuitem" type="button" class="menubar-item"
               aria-haspopup="menu" aria-expanded="false" popovertarget="helpmenu">Help</button>
             <ul role="menu" focusgroup="menu" id="helpmenu" popover aria-label="Help submenu" class="submenu">
-              <li role="none"><button role="menuitem" type="button" class="submenu-item" autofocus>Documentation</button></li>
-              <li role="none"><button role="menuitem" type="button" class="submenu-item">About</button></li>
+              <li role="none"><button type="button" class="submenu-item" autofocus>Documentation</button></li>
+              <li role="none"><button type="button" class="submenu-item">About</button></li>
             </ul>
           </li>
         </ul>
@@ -140,15 +140,14 @@
      aria-label="Application Menu" class="menubar"&gt;
     &lt;li role="none"&gt;
         &lt;button role="menuitem" type="button" class="menubar-item"
-            
              aria-haspopup="menu" aria-expanded="false"
              popovertarget="filemenu"&gt;File&lt;/button&gt;
         &lt;ul role="menu" focusgroup="menu"
              id="filemenu" popover aria-label="File submenu" class="submenu"&gt;
-            &lt;li role="none"&gt;&lt;button role="menuitem" type="button" class="submenu-item"
+            &lt;li role="none"&gt;&lt;button type="button" class="submenu-item"
                  autofocus&gt;New&lt;/button&gt;&lt;/li&gt;
-            &lt;li role="none"&gt;&lt;button role="menuitem" type="button" class="submenu-item"&gt;Open&lt;/button&gt;&lt;/li&gt;
-            &lt;li role="none"&gt;&lt;button role="menuitem" type="button" class="submenu-item"&gt;Save&lt;/button&gt;&lt;/li&gt;
+            &lt;li role="none"&gt;&lt;button type="button" class="submenu-item"&gt;Open&lt;/button&gt;&lt;/li&gt;
+            &lt;li role="none"&gt;&lt;button type="button" class="submenu-item"&gt;Save&lt;/button&gt;&lt;/li&gt;
         &lt;/ul&gt;
     &lt;/li&gt;
     &lt;!-- More menu items... --&gt;

--- a/focusgroup/radiogroup.html
+++ b/focusgroup/radiogroup.html
@@ -27,9 +27,7 @@
       <h2 id="comparison-native-vs-focusgroup">Comparison: Native vs. Focusgroup</h2>
       <p>
         Side-by-side comparison showing that a <code>focusgroup</code>
-        radio group
-        can behave identically to native <code>&lt;input
-                    type="radio"&gt;</code>.
+        radio group can behave comparably to native <code>&lt;input type="radio"&gt;</code>.
       </p>
 
       <div class="try-it">
@@ -38,6 +36,8 @@
         by default (matching native radio behavior). Toggle the switch to
         disable it and see how arrow keys move focus without selecting.
       </div>
+
+      <div class="attr-label">focusgroup="radiogroup block wrap nomemory"</div>
 
       <div class="demo-container">
         <div class="comparison">
@@ -58,7 +58,7 @@
               <span class="toggle-slider"></span>
               Selection follows focus
             </label>
-            <div role="radiogroup" focusgroup="radiogroup block" aria-label="Favorite color" class="radio-group radio-group-column">
+            <div role="radiogroup" focusgroup="radiogroup block wrap nomemory" aria-label="Favorite color" class="radio-group radio-group-column">
               <span role="radio" aria-checked="true" tabindex="0" class="radio-option checked" focusgroupstart>Red</span>
               <span role="radio" aria-checked="false" tabindex="0" class="radio-option">Green</span>
               <span role="radio" aria-checked="false" tabindex="0" class="radio-option">Blue</span>
@@ -85,30 +85,32 @@
           <code>role="radio"</code>.
         </li>
         <li><code>radiogroup</code> has no default axis modifier. Unlike
-          <code>menu</code> (which defaults to <code>block</code>) or
-          <code>tablist</code> (which defaults to <code>inline</code>),
+          <code>menu</code> (which defaults to <code>block wrap</code>) or
+          <code>tablist</code> (which defaults to <code>inline wrap</code>),
           you must explicitly add <code>block</code> or <code>inline</code>.
-          <code>block</code> here activates Up/Down arrow navigation.</li>
+          <code>block</code> here sets the navigation axis to Up/Down.
+          <code>wrap</code> matches native radio behavior, looping from last to first
+          and first to last.</li>
         <li><code>&lt;span role="radio"&gt;</code> is not natively focusable.
           Give every radio <code>tabindex="0"</code> so the browser can
           focus it. <code>focusgroup</code> collapses those into one tab
           stop. JavaScript moves <code>focusgroupstart</code> to the
-          selected item on each selection change so Tab re-entry lands
-          on the checked option.</li>
+          selected item on each selection change. Combined with
+          <code>nomemory</code>, Tab re-entry lands on the checked option.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="radiogroup" focusgroup="radiogroup block" aria-label="Favorite
-     color"&gt;
-    &lt;span role="radio" class="radio-option checked" aria-checked="true"
-         tabindex="0" focusgroupstart&gt;Red&lt;/span&gt;
-    &lt;span role="radio" class="radio-option" aria-checked="false"
-         tabindex="0"&gt;Green&lt;/span&gt;
-    &lt;span role="radio" class="radio-option" aria-checked="false"
-         tabindex="0"&gt;Blue&lt;/span&gt;
-    &lt;span role="radio" class="radio-option" aria-checked="false"
-         tabindex="0"&gt;Purple&lt;/span&gt;
+        <pre><code>&lt;div role="radiogroup" focusgroup="radiogroup block wrap nomemory"
+     aria-label="Favorite color" class="radio-group radio-group-column"&gt;
+    &lt;span role="radio" aria-checked="true" tabindex="0"
+          class="radio-option checked" focusgroupstart&gt;Red&lt;/span&gt;
+    &lt;span role="radio" aria-checked="false" tabindex="0"
+          class="radio-option"&gt;Green&lt;/span&gt;
+    &lt;span role="radio" aria-checked="false" tabindex="0"
+          class="radio-option"&gt;Blue&lt;/span&gt;
+    &lt;span role="radio" aria-checked="false" tabindex="0"
+          class="radio-option"&gt;Purple&lt;/span&gt;
 &lt;/div&gt;</code></pre>
       </details>
     </section>

--- a/focusgroup/radiogroup.html
+++ b/focusgroup/radiogroup.html
@@ -58,11 +58,11 @@
               <span class="toggle-slider"></span>
               Selection follows focus
             </label>
-            <div role="radiogroup" focusgroup="radiogroup block wrap nomemory" aria-label="Favorite color" class="radio-group radio-group-column">
-              <span role="radio" aria-checked="true" tabindex="0" class="radio-option checked" focusgroupstart>Red</span>
-              <span role="radio" aria-checked="false" tabindex="0" class="radio-option">Green</span>
-              <span role="radio" aria-checked="false" tabindex="0" class="radio-option">Blue</span>
-              <span role="radio" aria-checked="false" tabindex="0" class="radio-option">Purple</span>
+            <div focusgroup="radiogroup block wrap nomemory" aria-label="Favorite color" class="radio-group radio-group-column">
+              <span aria-checked="true" tabindex="0" class="radio-option checked" focusgroupstart>Red</span>
+              <span aria-checked="false" tabindex="0" class="radio-option">Green</span>
+              <span aria-checked="false" tabindex="0" class="radio-option">Blue</span>
+              <span aria-checked="false" tabindex="0" class="radio-option">Purple</span>
             </div>
           </div>
         </div>
@@ -91,25 +91,29 @@
           <code>block</code> here sets the navigation axis to Up/Down.
           <code>wrap</code> matches native radio behavior, looping from last to first
           and first to last.</li>
-        <li><code>&lt;span role="radio"&gt;</code> is not natively focusable.
-          Give every radio <code>tabindex="0"</code> so the browser can
+        <li>The <code>radiogroup</code> token maps <code>role="radiogroup"</code>
+          on the container and infers <code>role="radio"</code> on each
+          generic child (including <code>&lt;span&gt;</code>).</li>
+        <li><code>&lt;span&gt;</code> is not natively focusable.
+          Give every item <code>tabindex="0"</code> so the browser can
           focus it. <code>focusgroup</code> collapses those into one tab
-          stop. JavaScript moves <code>focusgroupstart</code> to the
+          stop.</li>
+        <li>JavaScript moves <code>focusgroupstart</code> to the
           selected item on each selection change. Combined with
           <code>nomemory</code>, Tab re-entry lands on the checked option.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="radiogroup" focusgroup="radiogroup block wrap nomemory"
+        <pre><code>&lt;div focusgroup="radiogroup block wrap nomemory"
      aria-label="Favorite color" class="radio-group radio-group-column"&gt;
-    &lt;span role="radio" aria-checked="true" tabindex="0"
+    &lt;span aria-checked="true" tabindex="0"
           class="radio-option checked" focusgroupstart&gt;Red&lt;/span&gt;
-    &lt;span role="radio" aria-checked="false" tabindex="0"
+    &lt;span aria-checked="false" tabindex="0"
           class="radio-option"&gt;Green&lt;/span&gt;
-    &lt;span role="radio" aria-checked="false" tabindex="0"
+    &lt;span aria-checked="false" tabindex="0"
           class="radio-option"&gt;Blue&lt;/span&gt;
-    &lt;span role="radio" aria-checked="false" tabindex="0"
+    &lt;span aria-checked="false" tabindex="0"
           class="radio-option"&gt;Purple&lt;/span&gt;
 &lt;/div&gt;</code></pre>
       </details>

--- a/focusgroup/radiogroup.html
+++ b/focusgroup/radiogroup.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Focusgroup: Radio Group Pattern</title>
   <link rel="icon" type="image/png" href="https://edgestatic.azureedge.net/welcome/static/favicon.png">
@@ -13,8 +12,8 @@
 <body>
   <header class="page-header">
     <h1>Radio Group Pattern</h1>
-    <p>Custom radio buttons with arrow-key navigation powered by
-      <code>focusgroup</code>.
+    <p>Custom radio buttons using <code>focusgroup</code> for
+      arrow-key navigation.
     </p>
     <nav><a href="index.html">← All Demos</a></nav>
   </header>
@@ -35,9 +34,9 @@
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>↓</kbd> <kbd>↑</kbd> to
-        navigate in both groups.
-        Toggle the switch on the right to match native radio behavior,
-        where selection follows focus.
+        navigate in both groups. Selection-follows-focus is <strong>on</strong>
+        by default (matching native radio behavior). Toggle the switch to
+        disable it and see how arrow keys move focus without selecting.
       </div>
 
       <div class="demo-container">
@@ -46,24 +45,24 @@
             <h3>Native Radio Buttons</h3>
             <fieldset>
               <legend>Favorite color</legend>
-              <label><input type="radio" name="native-color" value="red" checked> Red</label><br>
-              <label><input type="radio" name="native-color" value="green"> Green</label><br>
-              <label><input type="radio" name="native-color" value="blue"> Blue</label><br>
+              <label><input type="radio" name="native-color" value="red" checked> Red</label>
+              <label><input type="radio" name="native-color" value="green"> Green</label>
+              <label><input type="radio" name="native-color" value="blue"> Blue</label>
               <label><input type="radio" name="native-color" value="purple"> Purple</label>
             </fieldset>
           </div>
           <div class="comparison-column">
             <h3>Focusgroup Radio Group</h3>
             <label class="toggle-switch">
-              <input type="checkbox" id="selection-follows-focus">
+              <input type="checkbox" id="selection-follows-focus" checked>
               <span class="toggle-slider"></span>
               Selection follows focus
             </label>
-            <div focusgroup="radiogroup" aria-label="Favorite color" class="radio-group radio-group-column">
-              <span aria-checked="true" tabindex="0" class="radio-option checked" focusgroupstart>Red</span>
-              <span aria-checked="false" tabindex="0" class="radio-option">Green</span>
-              <span aria-checked="false" tabindex="0" class="radio-option">Blue</span>
-              <span aria-checked="false" tabindex="0" class="radio-option">Purple</span>
+            <div role="radiogroup" focusgroup="radiogroup block" aria-label="Favorite color" class="radio-group radio-group-column">
+              <span role="radio" aria-checked="true" tabindex="0" class="radio-option checked" focusgroupstart>Red</span>
+              <span role="radio" aria-checked="false" tabindex="0" class="radio-option">Green</span>
+              <span role="radio" aria-checked="false" tabindex="0" class="radio-option">Blue</span>
+              <span role="radio" aria-checked="false" tabindex="0" class="radio-option">Purple</span>
             </div>
           </div>
         </div>
@@ -71,47 +70,61 @@
 
       <ul class="notice-list">
         <li>Both groups use arrow keys to navigate between options</li>
-        <li>Both are single tab stops — Tab enters, arrows navigate,
-          Tab exits</li>
-        <li>The <code>focusgroup</code> version gives you full control
-          over styling</li>
+        <li>Both are single tab stops. Tab enters, arrows navigate, and Tab exits</li>
+        <li>The <code>focusgroup</code> version can be styled with CSS
+          without browser-default appearance</li>
         <li>
+          <strong>Selection follows focus (on, default):</strong> Moving focus
+          also selects the option, matching native radio behavior and the
+          <a href="https://www.w3.org/WAI/ARIA/apg/patterns/radio/" target="_blank">APG Radio Group pattern</a>
+          requirement.
           <strong>Selection follows focus (off):</strong> Arrow keys
           only move focus;
           press <kbd>Enter</kbd> or <kbd>Space</kbd> to select.
-          <strong>Selection follows focus (on):</strong> Moving focus
-          also selects the option,
-          matching native radio behavior.
+          This mode is shown for comparison only. It is non-conformant for
+          <code>role="radio"</code>.
         </li>
+        <li><code>radiogroup</code> has no default axis modifier. Unlike
+          <code>menu</code> (which defaults to <code>block</code>) or
+          <code>tablist</code> (which defaults to <code>inline</code>),
+          you must explicitly add <code>block</code> or <code>inline</code>.
+          <code>block</code> here activates Up/Down arrow navigation.</li>
+        <li><code>&lt;span role="radio"&gt;</code> is not natively focusable.
+          Give every radio <code>tabindex="0"</code> so the browser can
+          focus it. <code>focusgroup</code> collapses those into one tab
+          stop. JavaScript moves <code>focusgroupstart</code> to the
+          selected item on each selection change so Tab re-entry lands
+          on the checked option.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="radiogroup" aria-label="Favorite
+        <pre><code>&lt;div role="radiogroup" focusgroup="radiogroup block" aria-label="Favorite
      color"&gt;
-    &lt;span class="radio-option checked" aria-checked="true" tabindex="0"
-         focusgroupstart&gt;Red&lt;/span&gt;
-    &lt;span class="radio-option" aria-checked="false"
+    &lt;span role="radio" class="radio-option checked" aria-checked="true"
+         tabindex="0" focusgroupstart&gt;Red&lt;/span&gt;
+    &lt;span role="radio" class="radio-option" aria-checked="false"
          tabindex="0"&gt;Green&lt;/span&gt;
-    &lt;span class="radio-option" aria-checked="false"
+    &lt;span role="radio" class="radio-option" aria-checked="false"
          tabindex="0"&gt;Blue&lt;/span&gt;
-    &lt;span class="radio-option" aria-checked="false"
+    &lt;span role="radio" class="radio-option" aria-checked="false"
          tabindex="0"&gt;Purple&lt;/span&gt;
 &lt;/div&gt;</code></pre>
       </details>
     </section>
 
     <section class="demo-section">
-      <h2 id="key-point-navigation-selection">Key Point: Navigation ≠ Selection</h2>
+      <h2 id="key-point-navigation-selection">Key Point: Navigation vs. Selection</h2>
       <p>
         With native <code>&lt;input type="radio"&gt;</code>, moving
-        focus with arrows also selects the option.
-        With <code>focusgroup</code>, navigation and selection are
-        <strong>decoupled by default</strong>.
-        You can add selection-follows-focus behavior in JavaScript
-        (toggle the switch above to see it),
-        or require an explicit <kbd>Enter</kbd>/<kbd>Space</kbd> to
-        confirm — giving you more flexibility.
+        focus with arrows also selects the option (selection-follows-focus).
+        The <a href="https://www.w3.org/WAI/ARIA/apg/patterns/radio/" target="_blank">APG Radio Group pattern</a>
+        normatively requires this behavior for <code>role="radio"</code>.
+        With <code>focusgroup</code>, selection-follows-focus is implemented
+        in JavaScript and is <strong>on by default</strong> in this demo.
+        The toggle above can disable it to show the non-conformant
+        "deferred selection" mode (where <kbd>Enter</kbd>/<kbd>Space</kbd>
+        confirms selection). It is provided for comparison only.
       </p>
     </section>
 

--- a/focusgroup/radiogroup.js
+++ b/focusgroup/radiogroup.js
@@ -8,8 +8,10 @@
 
    The toggle (#selection-follows-focus) lets the user switch
    between two modes:
-   - Off (default): arrows only move focus; Enter/Space selects.
-   - On: moving focus also selects, matching native <input type="radio">.
+   - On (default): moving focus also selects, matching native <input type="radio">
+     and the APG Radio Group pattern requirement.
+   - Off: arrows only move focus; Enter/Space selects.
+     This mode is non-conformant for role="radio" and is shown for comparison only.
 
    Requires shared.js to be loaded first.
    ============================================================ */
@@ -23,7 +25,16 @@
       '[focusgroup~="radiogroup"]',
       ".radio-option",
       "aria-checked",
-      "checked"
+      "checked",
+      function (target, items) {
+        items.forEach(function (item) {
+          if (item === target) {
+            item.setAttribute("focusgroupstart", "");
+          } else {
+            item.removeAttribute("focusgroupstart");
+          }
+        });
+      }
     );
 
     // Selection-follows-focus toggle
@@ -36,11 +47,7 @@
       items.forEach(function (item) {
         item.addEventListener("focus", function () {
           if (toggle.checked) {
-            items.forEach(function (i) {
-              var isSelected = i === item;
-              i.setAttribute("aria-checked", String(isSelected));
-              i.classList.toggle("checked", isSelected);
-            });
+            item.click();
           }
         });
       });

--- a/focusgroup/radiogroup.js
+++ b/focusgroup/radiogroup.js
@@ -1,5 +1,5 @@
 /* ============================================================
-   Focusgroup Demo — Radio Group
+   Focusgroup Demo - Radio Group
    ============================================================
    focusgroup handles arrow-key navigation between options.
    This file handles the remaining application logic:

--- a/focusgroup/shared.js
+++ b/focusgroup/shared.js
@@ -41,8 +41,9 @@ function checkFocusgroupSupport() {
  * @param {string} itemSelector     CSS selector for selectable items
  * @param {string} ariaAttr       ARIA attribute name ("aria-checked" or "aria-selected")
  * @param {string} [selectedClass]  CSS class to toggle on the selected item
+ * @param {Function} [afterSelect]  Optional callback called with (target, items) after each selection
  */
-function initSingleSelect(containerSelector, itemSelector, ariaAttr, selectedClass) {
+function initSingleSelect(containerSelector, itemSelector, ariaAttr, selectedClass, afterSelect) {
   "use strict";
 
   document.querySelectorAll(containerSelector).forEach(function (container) {
@@ -56,6 +57,9 @@ function initSingleSelect(containerSelector, itemSelector, ariaAttr, selectedCla
           item.classList.toggle(selectedClass, isSelected);
         }
       });
+      if (afterSelect) {
+        afterSelect(target, items);
+      }
     }
 
     items.forEach(function (item) {

--- a/focusgroup/shared.js
+++ b/focusgroup/shared.js
@@ -1,5 +1,5 @@
 /* ============================================================
-   Focusgroup Demos — Shared Utilities
+   Focusgroup Demos - Shared Utilities
    ============================================================
    Common code used across multiple demo pages.
    Include this file before any per-page script.
@@ -33,9 +33,10 @@ function checkFocusgroupSupport() {
 
 /**
  * Set up single-select behavior for a group of items.
- * Adds click and Enter/Space handlers that toggle a boolean
- * ARIA attribute (e.g. aria-checked or aria-selected) so that
- * exactly one item in the group is "on" at a time.
+ * Adds click and Enter/Space handlers so that exactly one item
+ * in the group has its ARIA attribute (e.g. aria-selected) set
+ * to "true" at a time. Activating the already-selected item
+ * has no effect.
  *
  * @param {string} containerSelector  CSS selector for the container(s)
  * @param {string} itemSelector     CSS selector for selectable items

--- a/focusgroup/style.css
+++ b/focusgroup/style.css
@@ -494,6 +494,33 @@ body {
   outline-offset: -2px;
 }
 
+/* Anchor positioning: pair each trigger with its submenu */
+[popovertarget="filemenu"] { anchor-name: --file-trigger; }
+#filemenu { position-anchor: --file-trigger; }
+[popovertarget="editmenu"] { anchor-name: --edit-trigger; }
+#editmenu { position-anchor: --edit-trigger; }
+[popovertarget="viewmenu"] { anchor-name: --view-trigger; }
+#viewmenu { position-anchor: --view-trigger; }
+[popovertarget="helpmenu"] { anchor-name: --help-trigger; }
+#helpmenu { position-anchor: --help-trigger; }
+
+/* ----- Additional Concepts ----- */
+.opted-out-button {
+  opacity: 0.6;
+}
+
+.reading-flow-toolbar {
+  display: flex;
+  flex-direction: row-reverse;
+  reading-flow: flex-visual;
+  gap: 0.35rem;
+}
+
+#feature-detect-result {
+  padding: 0.75rem;
+  border-radius: 4px;
+}
+
 /* ----- Radio Group ----- */
 .radio-group {
   display: flex;

--- a/focusgroup/style.css
+++ b/focusgroup/style.css
@@ -787,3 +787,15 @@ body {
     padding: 1rem;
   }
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/focusgroup/style.css
+++ b/focusgroup/style.css
@@ -1,5 +1,5 @@
 /* ============================================================
-   Focusgroup Demos — Shared Stylesheet
+   Focusgroup Demos - Shared Stylesheet
    ============================================================ */
 
 /* ----- Reset & Base ----- */
@@ -765,7 +765,8 @@ body {
 .mb-1 { margin-bottom: 1rem; }
 .flex-row { display: flex; flex-direction: row; }
 .gap-1 { gap: 1rem; }
-.visually-hidden {
+.visually-hidden,
+.sr-only {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -788,14 +789,4 @@ body {
   }
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
+

--- a/focusgroup/tablist.html
+++ b/focusgroup/tablist.html
@@ -12,8 +12,8 @@
 <body>
   <header class="page-header">
     <h1>Tablist Pattern</h1>
-    <p>Tab controls with arrow-key navigation, wrapping, and nomemory for
-      selected-tab re-entry.</p>
+    <p>Tab controls with arrow-key navigation, wrapping, and JavaScript-managed
+      <code>focusgroupstart</code> for selected-tab re-entry.</p>
     <nav><a href="index.html">← All Demos</a></nav>
   </header>
 
@@ -40,7 +40,9 @@
         navigate between tabs.
         Press <kbd>→</kbd> past the last tab to wrap to the first.
         <kbd>Tab</kbd> moves to the panel content. Focusing a tab
-        activates that panel. Arrow keys switch between tabs.
+        activates that panel. Tab away from the tablist, then Tab
+        back in — focus returns to the selected tab, not the last one
+        you arrowed to.
       </div>
 
       <div class="demo-container">
@@ -56,9 +58,8 @@
         </div>
         <div role="tabpanel" id="panel-overview" aria-labelledby="tab-overview" tabindex="0" class="tabpanel">
           <h3>Overview</h3>
-          <p>The <code>focusgroup</code> attribute provides
-            declarative arrow-key navigation for composite widgets
-            without JavaScript.</p>
+          <p>The <code>focusgroup</code> attribute gives composite widgets
+            declarative arrow-key navigation without JavaScript.</p>
         </div>
         <div role="tabpanel" id="panel-features" aria-labelledby="tab-features" tabindex="0" class="tabpanel" hidden>
           <h3>Features</h3>
@@ -98,7 +99,7 @@
       <details class="source-code">
         <summary>View source</summary>
         <pre><code>&lt;div role="tablist" focusgroup="tablist nomemory"
-     aria-label="Sections"&gt;
+     aria-label="Sections" class="tablist"&gt;
     &lt;button role="tab" type="button" id="tab-overview" class="tab selected"
          aria-selected="true"
             aria-controls="panel-overview"
@@ -128,17 +129,18 @@
       <h2 id="vertical-tablist">Vertical Tablist</h2>
       <p>A vertical tablist using <code>block</code> axis for Up/Down
         arrow navigation.</p>
-      <div class="attr-label">focusgroup="tablist block nomemory"</div>
+      <div class="attr-label">focusgroup="tablist block wrap nomemory"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>↓</kbd> and <kbd>↑</kbd> to
-        navigate tabs. Left/Right arrows do nothing. Selecting a
+        navigate tabs. Press <kbd>↓</kbd> past the last tab to wrap
+        to the first. Left/Right arrows do nothing. Selecting a
         tab shows its panel.
       </div>
 
       <div class="demo-container">
         <div class="tab-wrapper-vertical">
-          <div role="tablist" focusgroup="tablist block nomemory" aria-orientation="vertical" aria-label="Settings"
+          <div role="tablist" focusgroup="tablist block wrap nomemory" aria-orientation="vertical" aria-label="Settings"
             class="tablist-vertical">
             <button role="tab" type="button" class="tab selected" aria-selected="true" aria-controls="vpanel-general"
               id="vtab-general" focusgroupstart>General</button>
@@ -167,17 +169,17 @@
       </div>
 
       <ul class="notice-list">
-        <li><code>block</code> overrides the default <code>inline</code> axis, so Up/Down arrows navigate instead of Left/Right</li>
+        <li><code>block</code> overrides the default <code>inline wrap</code>, so Up/Down arrows navigate instead of Left/Right and wrapping is disabled unless <code>wrap</code> is re-added explicitly</li>
         <li>Pair with <code>aria-orientation="vertical"</code> for
           screen readers</li>
-        <li>Same <code>wrap</code> and <code>nomemory</code> behavior
-          as the horizontal version</li>
+        <li>Same <code>wrap</code>, <code>nomemory</code>, and JavaScript-managed <code>focusgroupstart</code> behavior
+          as the horizontal version. JavaScript moves <code>focusgroupstart</code> to the selected tab on each selection.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="tablist" focusgroup="tablist block nomemory"
-     aria-orientation="vertical" aria-label="Settings"&gt;
+        <pre><code>&lt;div role="tablist" focusgroup="tablist block wrap nomemory"
+     aria-orientation="vertical" aria-label="Settings" class="tablist-vertical"&gt;
     &lt;button role="tab" type="button" id="vtab-general" class="tab selected"
             aria-selected="true" aria-controls="vpanel-general"
             focusgroupstart&gt;General&lt;/button&gt;

--- a/focusgroup/tablist.html
+++ b/focusgroup/tablist.html
@@ -46,14 +46,14 @@
       </div>
 
       <div class="demo-container">
-        <div role="tablist" focusgroup="tablist nomemory" aria-label="Sections" class="tablist">
-          <button role="tab" type="button" class="tab selected" aria-selected="true" aria-controls="panel-overview"
+        <div focusgroup="tablist nomemory" aria-label="Sections" class="tablist">
+          <button type="button" class="tab selected" aria-selected="true" aria-controls="panel-overview"
             id="tab-overview" focusgroupstart>Overview</button>
-          <button role="tab" type="button" class="tab" aria-selected="false" aria-controls="panel-features"
+          <button type="button" class="tab" aria-selected="false" aria-controls="panel-features"
             id="tab-features">Features</button>
-          <button role="tab" type="button" class="tab" aria-selected="false" aria-controls="panel-pricing"
+          <button type="button" class="tab" aria-selected="false" aria-controls="panel-pricing"
             id="tab-pricing">Pricing</button>
-          <button role="tab" type="button" class="tab" aria-selected="false" aria-controls="panel-faq"
+          <button type="button" class="tab" aria-selected="false" aria-controls="panel-faq"
             id="tab-faq">FAQ</button>
         </div>
         <div role="tabpanel" id="panel-overview" aria-labelledby="tab-overview" tabindex="0" class="tabpanel">
@@ -98,18 +98,18 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="tablist" focusgroup="tablist nomemory"
+        <pre><code>&lt;div focusgroup="tablist nomemory"
      aria-label="Sections" class="tablist"&gt;
-    &lt;button role="tab" type="button" class="tab selected"
+    &lt;button type="button" class="tab selected"
          aria-selected="true" aria-controls="panel-overview"
          id="tab-overview" focusgroupstart&gt;Overview&lt;/button&gt;
-    &lt;button role="tab" type="button" class="tab"
+    &lt;button type="button" class="tab"
          aria-selected="false" aria-controls="panel-features"
          id="tab-features"&gt;Features&lt;/button&gt;
-    &lt;button role="tab" type="button" class="tab"
+    &lt;button type="button" class="tab"
          aria-selected="false" aria-controls="panel-pricing"
          id="tab-pricing"&gt;Pricing&lt;/button&gt;
-    &lt;button role="tab" type="button" class="tab"
+    &lt;button type="button" class="tab"
          aria-selected="false" aria-controls="panel-faq"
          id="tab-faq"&gt;FAQ&lt;/button&gt;
 &lt;/div&gt;
@@ -142,13 +142,13 @@
 
       <div class="demo-container">
         <div class="tab-wrapper-vertical">
-          <div role="tablist" focusgroup="tablist block wrap nomemory" aria-orientation="vertical" aria-label="Settings"
+          <div focusgroup="tablist block wrap nomemory" aria-orientation="vertical" aria-label="Settings"
             class="tablist-vertical">
-            <button role="tab" type="button" class="tab selected" aria-selected="true" aria-controls="vpanel-general"
+            <button type="button" class="tab selected" aria-selected="true" aria-controls="vpanel-general"
               id="vtab-general" focusgroupstart>General</button>
-            <button role="tab" type="button" class="tab" aria-selected="false" aria-controls="vpanel-privacy"
+            <button type="button" class="tab" aria-selected="false" aria-controls="vpanel-privacy"
               id="vtab-privacy">Privacy</button>
-            <button role="tab" type="button" class="tab" aria-selected="false" aria-controls="vpanel-advanced"
+            <button type="button" class="tab" aria-selected="false" aria-controls="vpanel-advanced"
               id="vtab-advanced">Advanced</button>
           </div>
           <div role="tabpanel" id="vpanel-general" aria-labelledby="vtab-general" tabindex="0" class="tabpanel">
@@ -182,15 +182,15 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="tablist" focusgroup="tablist block wrap nomemory"
+        <pre><code>&lt;div focusgroup="tablist block wrap nomemory"
      aria-orientation="vertical" aria-label="Settings" class="tablist-vertical"&gt;
-    &lt;button role="tab" type="button" class="tab selected"
+    &lt;button type="button" class="tab selected"
             aria-selected="true" aria-controls="vpanel-general"
             id="vtab-general" focusgroupstart&gt;General&lt;/button&gt;
-    &lt;button role="tab" type="button" class="tab"
+    &lt;button type="button" class="tab"
             aria-selected="false" aria-controls="vpanel-privacy"
             id="vtab-privacy"&gt;Privacy&lt;/button&gt;
-    &lt;button role="tab" type="button" class="tab"
+    &lt;button type="button" class="tab"
             aria-selected="false" aria-controls="vpanel-advanced"
             id="vtab-advanced"&gt;Advanced&lt;/button&gt;
 &lt;/div&gt;
@@ -241,12 +241,12 @@
       </div>
 
       <div class="demo-container">
-        <div role="tablist" focusgroup="tablist nomemory" aria-label="Articles" class="tablist">
-          <button role="tab" type="button" class="tab selected" aria-selected="true" aria-controls="long-tpanel1"
+        <div focusgroup="tablist nomemory" aria-label="Articles" class="tablist">
+          <button type="button" class="tab selected" aria-selected="true" aria-controls="long-tpanel1"
             id="long-tab1" focusgroupstart>The Problem</button>
-          <button role="tab" type="button" class="tab" aria-selected="false" aria-controls="long-tpanel2"
+          <button type="button" class="tab" aria-selected="false" aria-controls="long-tpanel2"
             id="long-tab2">The Mitigation</button>
-          <button role="tab" type="button" class="tab" aria-selected="false" aria-controls="long-tpanel3"
+          <button type="button" class="tab" aria-selected="false" aria-controls="long-tpanel3"
             id="long-tab3">When To Use</button>
         </div>
         <div role="tabpanel" id="long-tpanel1" aria-labelledby="long-tab1" tabindex="0"
@@ -343,9 +343,9 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="tablist" focusgroup="tablist nomemory"
+        <pre><code>&lt;div focusgroup="tablist nomemory"
      aria-label="Articles" class="tablist"&gt;
-    &lt;button role="tab" type="button" class="tab selected"
+    &lt;button type="button" class="tab selected"
             aria-selected="true" aria-controls="long-tpanel1"
             id="long-tab1" focusgroupstart&gt;The Problem&lt;/button&gt;
     &lt;!-- more tabs ... --&gt;

--- a/focusgroup/tablist.html
+++ b/focusgroup/tablist.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Focusgroup: Tablist Pattern</title>
   <link rel="icon" type="image/png" href="https://edgestatic.azureedge.net/welcome/static/favicon.png">
@@ -13,7 +12,7 @@
 <body>
   <header class="page-header">
     <h1>Tablist Pattern</h1>
-    <p>Tab controls with arrow-key navigation, wrapping, and no-memory for
+    <p>Tab controls with arrow-key navigation, wrapping, and nomemory for
       selected-tab re-entry.</p>
     <nav><a href="index.html">← All Demos</a></nav>
   </header>
@@ -27,24 +26,25 @@
       <h2 id="horizontal-tablist-with-wrapping">Horizontal Tablist with Wrapping</h2>
       <p>
         A tab control using <code>focusgroup</code> for arrow-key
-        navigation. The <code>wrap</code>
-        token enables wrap-around, and <code>no-memory</code> ensures
-        focus always returns to the
-        selected tab (not the last-focused one).
+        navigation. The <code>tablist</code> behavior token implies
+        <code>inline wrap</code> by default, so wrapping is active without
+        an explicit <code>wrap</code> token. With <code>nomemory</code>
+        and a little JavaScript to move <code>focusgroupstart</code>,
+        re-entry always lands on the selected tab instead of the
+        last-focused one.
       </p>
-      <div class="attr-label">focusgroup="tablist inline wrap
-        no-memory"</div>
+      <div class="attr-label">focusgroup="tablist nomemory"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>→</kbd> and <kbd>←</kbd> to
         navigate between tabs.
         Press <kbd>→</kbd> past the last tab to wrap to the first.
-        <kbd>Tab</kbd> moves to the panel content. Focus on tab selects
-        panel content.
+        <kbd>Tab</kbd> moves to the panel content. Focusing a tab
+        activates that panel. Arrow keys switch between tabs.
       </div>
 
       <div class="demo-container">
-        <div focusgroup="tablist inline wrap no-memory" aria-label="Sections" class="tablist">
+        <div role="tablist" focusgroup="tablist nomemory" aria-label="Sections" class="tablist">
           <button role="tab" type="button" class="tab selected" aria-selected="true" aria-controls="panel-overview"
             id="tab-overview" focusgroupstart>Overview</button>
           <button role="tab" type="button" class="tab" aria-selected="false" aria-controls="panel-features"
@@ -63,13 +63,12 @@
         <div role="tabpanel" id="panel-features" aria-labelledby="tab-features" tabindex="0" class="tabpanel" hidden>
           <h3>Features</h3>
           <p>Arrow-key navigation, wrapping, axis locking, focus
-            memory, grid navigation, and more — all with a single
-            HTML attribute.</p>
+            memory, and grid navigation, all without JavaScript.</p>
         </div>
         <div role="tabpanel" id="panel-pricing" aria-labelledby="tab-pricing" tabindex="0" class="tabpanel" hidden>
           <h3>Pricing</h3>
-          <p>It's free! <code>focusgroup</code> is a native HTML
-            attribute — no libraries or frameworks needed.</p>
+          <p><code>focusgroup</code> is a native HTML
+            attribute; no libraries or frameworks needed.</p>
         </div>
         <div role="tabpanel" id="panel-faq" aria-labelledby="tab-faq" tabindex="0" class="tabpanel" hidden>
           <h3>FAQ</h3>
@@ -83,40 +82,42 @@
       </div>
 
       <ul class="notice-list">
-        <li><code>inline wrap</code> enables Left/Right navigation with
-          wrap-around</li>
-        <li><code>no-memory</code> ensures re-entry always goes to the
-          selected tab, not the last-focused one</li>
+        <li>The <code>tablist</code> behavior token implies <code>inline wrap</code> by default, so Left/Right navigation with wrap-around works without specifying these tokens explicitly</li>
+        <li>With <code>nomemory</code>, re-entry always goes to the
+          selected tab, not the last-focused one
+          (JavaScript moves <code>focusgroupstart</code> to the
+          selected tab on each selection to make this work)</li>
         <li><code>focusgroupstart</code> on the selected tab marks the
           entry point</li>
         <li>JavaScript handles panel visibility and
-          <code>aria-selected</code> state — focusgroup handles
+          <code>aria-selected</code> state; focusgroup handles
           navigation
         </li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="tablist inline wrap no-memory"
+        <pre><code>&lt;div role="tablist" focusgroup="tablist nomemory"
      aria-label="Sections"&gt;
-    &lt;button role="tab" type="button" class="tab selected"
+    &lt;button role="tab" type="button" id="tab-overview" class="tab selected"
          aria-selected="true"
             aria-controls="panel-overview"
                  focusgroupstart&gt;Overview&lt;/button&gt;
-    &lt;button role="tab" type="button" class="tab" aria-selected="false"
+    &lt;button role="tab" type="button" id="tab-features" class="tab" aria-selected="false"
             aria-controls="panel-features"&gt;Features&lt;/button&gt;
-    &lt;button role="tab" type="button" class="tab" aria-selected="false"
+    &lt;button role="tab" type="button" id="tab-pricing" class="tab" aria-selected="false"
             aria-controls="panel-pricing"&gt;Pricing&lt;/button&gt;
-    &lt;button role="tab" type="button" class="tab" aria-selected="false"
+    &lt;button role="tab" type="button" id="tab-faq" class="tab" aria-selected="false"
             aria-controls="panel-faq"&gt;FAQ&lt;/button&gt;
 &lt;/div&gt;
-&lt;div role="tabpanel" id="panel-overview" tabindex="0"&gt;...&lt;/div&gt;
-&lt;div role="tabpanel" id="panel-features" tabindex="0"
-     hidden&gt;...&lt;/div&gt;
-&lt;div role="tabpanel" id="panel-pricing" tabindex="0"
-     hidden&gt;...&lt;/div&gt;
-&lt;div role="tabpanel" id="panel-faq" tabindex="0"
-     hidden&gt;...&lt;/div&gt;</code></pre>
+&lt;div role="tabpanel" id="panel-overview" aria-labelledby="tab-overview"
+     tabindex="0" class="tabpanel"&gt;...&lt;/div&gt;
+&lt;div role="tabpanel" id="panel-features" aria-labelledby="tab-features"
+     tabindex="0" class="tabpanel" hidden&gt;...&lt;/div&gt;
+&lt;div role="tabpanel" id="panel-pricing" aria-labelledby="tab-pricing"
+     tabindex="0" class="tabpanel" hidden&gt;...&lt;/div&gt;
+&lt;div role="tabpanel" id="panel-faq" aria-labelledby="tab-faq"
+     tabindex="0" class="tabpanel" hidden&gt;...&lt;/div&gt;</code></pre>
       </details>
     </section>
 
@@ -127,8 +128,7 @@
       <h2 id="vertical-tablist">Vertical Tablist</h2>
       <p>A vertical tablist using <code>block</code> axis for Up/Down
         arrow navigation.</p>
-      <div class="attr-label">focusgroup="tablist block wrap
-        no-memory"</div>
+      <div class="attr-label">focusgroup="tablist block nomemory"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>↓</kbd> and <kbd>↑</kbd> to
@@ -138,7 +138,7 @@
 
       <div class="demo-container">
         <div class="tab-wrapper-vertical">
-          <div focusgroup="tablist block wrap no-memory" aria-orientation="vertical" aria-label="Settings"
+          <div role="tablist" focusgroup="tablist block nomemory" aria-orientation="vertical" aria-label="Settings"
             class="tablist-vertical">
             <button role="tab" type="button" class="tab selected" aria-selected="true" aria-controls="vpanel-general"
               id="vtab-general" focusgroupstart>General</button>
@@ -167,30 +167,33 @@
       </div>
 
       <ul class="notice-list">
-        <li><code>block</code> restricts navigation to Up/Down
-          arrows</li>
+        <li><code>block</code> overrides the default <code>inline</code> axis, so Up/Down arrows navigate instead of Left/Right</li>
         <li>Pair with <code>aria-orientation="vertical"</code> for
           screen readers</li>
-        <li>Same <code>wrap</code> and <code>no-memory</code> behavior
+        <li>Same <code>wrap</code> and <code>nomemory</code> behavior
           as the horizontal version</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="tablist block wrap no-memory"
+        <pre><code>&lt;div role="tablist" focusgroup="tablist block nomemory"
      aria-orientation="vertical" aria-label="Settings"&gt;
-    &lt;button role="tab" class="tab selected" aria-selected="true"
-            aria-controls="vpanel-general"&gt;General&lt;/button&gt;
-    &lt;button role="tab" class="tab" aria-selected="false"
+    &lt;button role="tab" type="button" id="vtab-general" class="tab selected"
+            aria-selected="true" aria-controls="vpanel-general"
+            focusgroupstart&gt;General&lt;/button&gt;
+    &lt;button role="tab" type="button" id="vtab-privacy" class="tab"
+            aria-selected="false"
             aria-controls="vpanel-privacy"&gt;Privacy&lt;/button&gt;
-    &lt;button role="tab" class="tab" aria-selected="false"
+    &lt;button role="tab" type="button" id="vtab-advanced" class="tab"
+            aria-selected="false"
             aria-controls="vpanel-advanced"&gt;Advanced&lt;/button&gt;
 &lt;/div&gt;
-&lt;div role="tabpanel" id="vpanel-general" tabindex="0"&gt;...&lt;/div&gt;
-&lt;div role="tabpanel" id="vpanel-privacy" tabindex="0"
-     hidden&gt;...&lt;/div&gt;
-&lt;div role="tabpanel" id="vpanel-advanced" tabindex="0"
-     hidden&gt;...&lt;/div&gt;</code></pre>
+&lt;div role="tabpanel" id="vpanel-general" aria-labelledby="vtab-general"
+     tabindex="0" class="tabpanel"&gt;...&lt;/div&gt;
+&lt;div role="tabpanel" id="vpanel-privacy" aria-labelledby="vtab-privacy"
+     tabindex="0" class="tabpanel" hidden&gt;...&lt;/div&gt;
+&lt;div role="tabpanel" id="vpanel-advanced" aria-labelledby="vtab-advanced"
+     tabindex="0" class="tabpanel" hidden&gt;...&lt;/div&gt;</code></pre>
       </details>
     </section>
 
@@ -204,7 +207,7 @@
           between tabs instantly
           swaps the panel</strong>. If a panel has more content than fits
         on screen, the user
-        may never scroll through it — the next arrow press switches to
+        may never scroll through it; the next arrow press switches to
         a different panel entirely.
       </p>
       <p>
@@ -215,25 +218,24 @@
         to enter the panel, then uses arrow keys to scroll its content.
         Pressing <kbd>Tab</kbd>
         again exits the panel.
-        Other approaches — such as not using selection-follows-focus,
+        Other approaches, such as not using selection-follows-focus,
         adding a "read more" link,
-        or avoiding tabs entirely for long content — may be more
+        or avoiding tabs entirely for long content, may be more
         appropriate depending on the use case.
       </p>
-      <div class="attr-label">focusgroup="tablist inline wrap
-        no-memory"</div>
+      <div class="attr-label">focusgroup="tablist nomemory"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>→</kbd> <kbd>←</kbd> to
         switch tabs. Then press
-        <kbd>Tab</kbd> to enter the panel — use <kbd>↓</kbd>
+        <kbd>Tab</kbd> to enter the panel. Use <kbd>↓</kbd>
         <kbd>↑</kbd> to <strong>scroll</strong>
         the long content. Press <kbd>Tab</kbd> again to move past the
         panel.
       </div>
 
       <div class="demo-container">
-        <div focusgroup="tablist inline wrap no-memory" aria-label="Articles" class="tablist">
+        <div role="tablist" focusgroup="tablist nomemory" aria-label="Articles" class="tablist">
           <button role="tab" type="button" class="tab selected" aria-selected="true" aria-controls="long-tpanel1"
             id="long-tab1" focusgroupstart>The Problem</button>
           <button role="tab" type="button" class="tab" aria-selected="false" aria-controls="long-tpanel2"
@@ -247,12 +249,12 @@
           <p>When tabs use selection-follows-focus, each arrow press
             immediately
             switches the visible panel. This is efficient for short
-            panels — the
+            panels; the
             user can quickly scan all tabs without pressing Enter or
             Space.</p>
-          <p>But if a panel is tall — containing a lengthy article, a
+          <p>But if a panel is tall, containing a lengthy article, a
             long form,
-            or detailed documentation — the user may never scroll
+            or detailed documentation, the user may never scroll
             through it.
             Pressing <kbd>→</kbd> swaps the panel to the next tab's
             content,
@@ -293,9 +295,8 @@
             focusable element
             on the page, or <kbd>Shift+Tab</kbd> back to the tabs.
           </p>
-          <p>This approach preserves the fast tab-switching behavior
-            while giving
-            the user an explicit way to consume long content.</p>
+          <p>Fast tab-switching still works; the user just has an
+            explicit way to read through a long panel before moving on.</p>
         </div>
         <div role="tabpanel" id="long-tpanel3" aria-labelledby="long-tab3" tabindex="0"
           class="tabpanel tabpanel-scrollable" hidden>
@@ -317,11 +318,9 @@
             pattern from Demo 1 is ideal. The user sees all content at
             a glance
             and can arrow freely between tabs.</p>
-          <p>The key question is: <em>will the user miss important
-              content if
-              they arrow to the next tab?</em> If yes, constrain the
-            panel height
-            so the scrollbar provides a visual cue.</p>
+          <p>If arrowing away would skip content the user needs to
+            read, constrain the panel height so the scrollbar provides
+            a visual cue.</p>
         </div>
       </div>
 
@@ -329,24 +328,24 @@
         <li>Panels are scrollable regions (<code>tabindex="0"</code> +
           <code>max-height</code> + <code>overflow: auto</code>)
         </li>
-        <li><kbd>Tab</kbd> from the tablist enters the panel — arrow
+        <li><kbd>Tab</kbd> from the tablist enters the panel; arrow
           keys then scroll content</li>
-        <li>The visible scrollbar hints that more content exists below
-          the fold</li>
+        <li>The visible scrollbar signals that the panel has more content.</li>
         <li>This preserves fast tab switching while preventing content
           from being missed</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="tablist inline wrap no-memory"
+        <pre><code>&lt;div role="tablist" focusgroup="tablist nomemory"
      aria-label="Articles"&gt;
-    &lt;button role="tab" class="tab selected" aria-selected="true"
-            aria-controls="long-tpanel1"&gt;The Problem&lt;/button&gt;
+    &lt;button role="tab" type="button" id="long-tab1" class="tab selected"
+            aria-selected="true" aria-controls="long-tpanel1"
+            focusgroupstart&gt;The Problem&lt;/button&gt;
     &lt;!-- more tabs ... --&gt;
 &lt;/div&gt;
-&lt;div role="tabpanel" id="long-tpanel1" tabindex="0"
-     class="tabpanel-scrollable"&gt;
+&lt;div role="tabpanel" id="long-tpanel1" aria-labelledby="long-tab1"
+     tabindex="0" class="tabpanel tabpanel-scrollable"&gt;
     &lt;p&gt;Long panel content...&lt;/p&gt;
 &lt;/div&gt;
 
@@ -372,7 +371,7 @@
         <li>Toggling <code>aria-selected</code> on tabs</li>
         <li>Showing/hiding tab panels</li>
         <li>Moving <code>focusgroupstart</code> to the selected tab (so
-          <code>no-memory</code> re-entry lands on the active
+          <code>nomemory</code> re-entry lands on the active
           tab)
         </li>
       </ul>

--- a/focusgroup/tablist.html
+++ b/focusgroup/tablist.html
@@ -40,8 +40,8 @@
         navigate between tabs.
         Press <kbd>→</kbd> past the last tab to wrap to the first.
         <kbd>Tab</kbd> moves to the panel content. Focusing a tab
-        activates that panel. Tab away from the tablist, then Tab
-        back in — focus returns to the selected tab, not the last one
+        selects that panel (selection-follows-focus). Tab away from the tablist, then Tab
+        back in; focus returns to the selected tab, not the last one
         you arrowed to.
       </div>
 
@@ -100,16 +100,18 @@
         <summary>View source</summary>
         <pre><code>&lt;div role="tablist" focusgroup="tablist nomemory"
      aria-label="Sections" class="tablist"&gt;
-    &lt;button role="tab" type="button" id="tab-overview" class="tab selected"
-         aria-selected="true"
-            aria-controls="panel-overview"
-                 focusgroupstart&gt;Overview&lt;/button&gt;
-    &lt;button role="tab" type="button" id="tab-features" class="tab" aria-selected="false"
-            aria-controls="panel-features"&gt;Features&lt;/button&gt;
-    &lt;button role="tab" type="button" id="tab-pricing" class="tab" aria-selected="false"
-            aria-controls="panel-pricing"&gt;Pricing&lt;/button&gt;
-    &lt;button role="tab" type="button" id="tab-faq" class="tab" aria-selected="false"
-            aria-controls="panel-faq"&gt;FAQ&lt;/button&gt;
+    &lt;button role="tab" type="button" class="tab selected"
+         aria-selected="true" aria-controls="panel-overview"
+         id="tab-overview" focusgroupstart&gt;Overview&lt;/button&gt;
+    &lt;button role="tab" type="button" class="tab"
+         aria-selected="false" aria-controls="panel-features"
+         id="tab-features"&gt;Features&lt;/button&gt;
+    &lt;button role="tab" type="button" class="tab"
+         aria-selected="false" aria-controls="panel-pricing"
+         id="tab-pricing"&gt;Pricing&lt;/button&gt;
+    &lt;button role="tab" type="button" class="tab"
+         aria-selected="false" aria-controls="panel-faq"
+         id="tab-faq"&gt;FAQ&lt;/button&gt;
 &lt;/div&gt;
 &lt;div role="tabpanel" id="panel-overview" aria-labelledby="tab-overview"
      tabindex="0" class="tabpanel"&gt;...&lt;/div&gt;
@@ -169,7 +171,9 @@
       </div>
 
       <ul class="notice-list">
-        <li><code>block</code> overrides the default <code>inline wrap</code>, so Up/Down arrows navigate instead of Left/Right and wrapping is disabled unless <code>wrap</code> is re-added explicitly</li>
+        <li><code>block</code> overrides the default <code>inline wrap</code>. This demo
+          re-adds <code>wrap</code> explicitly to keep wrapping active on the
+          block axis, so Down from the last tab wraps to the first</li>
         <li>Pair with <code>aria-orientation="vertical"</code> for
           screen readers</li>
         <li>Same <code>wrap</code>, <code>nomemory</code>, and JavaScript-managed <code>focusgroupstart</code> behavior
@@ -180,15 +184,15 @@
         <summary>View source</summary>
         <pre><code>&lt;div role="tablist" focusgroup="tablist block wrap nomemory"
      aria-orientation="vertical" aria-label="Settings" class="tablist-vertical"&gt;
-    &lt;button role="tab" type="button" id="vtab-general" class="tab selected"
+    &lt;button role="tab" type="button" class="tab selected"
             aria-selected="true" aria-controls="vpanel-general"
-            focusgroupstart&gt;General&lt;/button&gt;
-    &lt;button role="tab" type="button" id="vtab-privacy" class="tab"
-            aria-selected="false"
-            aria-controls="vpanel-privacy"&gt;Privacy&lt;/button&gt;
-    &lt;button role="tab" type="button" id="vtab-advanced" class="tab"
-            aria-selected="false"
-            aria-controls="vpanel-advanced"&gt;Advanced&lt;/button&gt;
+            id="vtab-general" focusgroupstart&gt;General&lt;/button&gt;
+    &lt;button role="tab" type="button" class="tab"
+            aria-selected="false" aria-controls="vpanel-privacy"
+            id="vtab-privacy"&gt;Privacy&lt;/button&gt;
+    &lt;button role="tab" type="button" class="tab"
+            aria-selected="false" aria-controls="vpanel-advanced"
+            id="vtab-advanced"&gt;Advanced&lt;/button&gt;
 &lt;/div&gt;
 &lt;div role="tabpanel" id="vpanel-general" aria-labelledby="vtab-general"
      tabindex="0" class="tabpanel"&gt;...&lt;/div&gt;
@@ -321,7 +325,7 @@
             a glance
             and can arrow freely between tabs.</p>
           <p>If arrowing away would skip content the user needs to
-            read, constrain the panel height so the scrollbar provides
+            read, constrain the panel height so the scrollbar acts as
             a visual cue.</p>
         </div>
       </div>
@@ -340,10 +344,10 @@
       <details class="source-code">
         <summary>View source</summary>
         <pre><code>&lt;div role="tablist" focusgroup="tablist nomemory"
-     aria-label="Articles"&gt;
-    &lt;button role="tab" type="button" id="long-tab1" class="tab selected"
+     aria-label="Articles" class="tablist"&gt;
+    &lt;button role="tab" type="button" class="tab selected"
             aria-selected="true" aria-controls="long-tpanel1"
-            focusgroupstart&gt;The Problem&lt;/button&gt;
+            id="long-tab1" focusgroupstart&gt;The Problem&lt;/button&gt;
     &lt;!-- more tabs ... --&gt;
 &lt;/div&gt;
 &lt;div role="tabpanel" id="long-tpanel1" aria-labelledby="long-tab1"
@@ -355,6 +359,7 @@
 .tabpanel-scrollable {
     max-height: 12rem;
     overflow: auto;
+    scroll-behavior: smooth;
 }
 &lt;/style&gt;</code></pre>
       </details>

--- a/focusgroup/tablist.js
+++ b/focusgroup/tablist.js
@@ -48,6 +48,7 @@
 
       tabs.forEach(function (tab) {
         tab.addEventListener("focus", function () { selectTab(tab); });
+        tab.addEventListener("click", function () { selectTab(tab); });
         tab.addEventListener("keydown", function (e) {
           if (e.key === "Home") {
             e.preventDefault();

--- a/focusgroup/tablist.js
+++ b/focusgroup/tablist.js
@@ -6,7 +6,7 @@
    - Setting aria-selected on the active tab
    - Showing/hiding the associated tabpanel
    - Moving focusgroupstart to the active tab (so that
-     no-memory re-entry always lands on the selected tab)
+     nomemory re-entry always lands on the selected tab)
 
    Selection follows focus ("follow focus" tabs).
 
@@ -47,8 +47,16 @@
       }
 
       tabs.forEach(function (tab) {
-        tab.addEventListener("click", function () { selectTab(tab); });
         tab.addEventListener("focus", function () { selectTab(tab); });
+        tab.addEventListener("keydown", function (e) {
+          if (e.key === "Home") {
+            e.preventDefault();
+            tabs[0].focus();
+          } else if (e.key === "End") {
+            e.preventDefault();
+            tabs[tabs.length - 1].focus();
+          }
+        });
       });
     });
   }

--- a/focusgroup/tablist.js
+++ b/focusgroup/tablist.js
@@ -1,5 +1,5 @@
 /* ============================================================
-   Focusgroup Demo — Tablist
+   Focusgroup Demo - Tablist
    ============================================================
    focusgroup handles arrow-key navigation between tabs.
    This file handles the remaining application logic:

--- a/focusgroup/toolbar.html
+++ b/focusgroup/toolbar.html
@@ -51,16 +51,13 @@
         <li>Left/Right arrows move focus between buttons</li>
         <li><code>toolbar</code> defaults to horizontal (inline) navigation. No explicit <code>inline</code> modifier needed.</li>
         <li>No JavaScript is needed for focus management</li>
-        <li><strong>Note:</strong> Home and End keys for jumping to the
-          first/last item are <strong>not</strong> handled by
-          <code>focusgroup</code>. Add JavaScript handlers if your
-          toolbar requires them.</li>
+        <li><kbd>Home</kbd> and <kbd>End</kbd> are not built into <code>focusgroup</code>.
+          Add JavaScript handlers if your pattern requires them.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Text
-     formatting"&gt;
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Text formatting" class="toolbar-horizontal"&gt;
     &lt;button type="button"&gt;Bold&lt;/button&gt;
     &lt;button type="button"&gt;Italic&lt;/button&gt;
     &lt;button type="button"&gt;Underline&lt;/button&gt;
@@ -75,9 +72,9 @@
     <section class="demo-section">
       <h2 id="no-tabindex-management-needed">No <code>tabindex</code> Management Needed</h2>
       <p>With <code>focusgroup</code>, you don't need to set or manage
-        <code>tabindex</code> on any items. The browser automatically
-        collapses all focusable children into a single tab stop, with no
-        JavaScript "roving tabindex" boilerplate required.
+        <code>tabindex</code> on any items. The browser collapses all
+        focusable children into a single tab stop, with no JavaScript
+        "roving tabindex" boilerplate required.
       </p>
       <div class="attr-label">focusgroup="toolbar"</div>
 
@@ -108,7 +105,7 @@
       <details class="source-code">
         <summary>View source</summary>
         <pre><code>&lt;div role="toolbar" focusgroup="toolbar"
-     aria-label="Document actions"&gt;
+     aria-label="Document actions" class="toolbar-horizontal"&gt;
     &lt;button type="button"&gt;New&lt;/button&gt;
     &lt;button type="button"&gt;Open&lt;/button&gt;
     &lt;button type="button"&gt;Save&lt;/button&gt;
@@ -135,7 +132,7 @@
         <strong>Try it:</strong> Press <kbd>Tab</kbd> to enter. Focus
         lands on "Middle (Entry)" because <code>focusgroupstart</code>
         marks it as the entry point. With <code>nomemory</code>,
-        focus returns here every time — not just on the first visit.
+        focus returns here every time, not just on the first visit.
       </div>
 
       <div class="demo-container">
@@ -158,7 +155,7 @@
       <details class="source-code">
         <summary>View source</summary>
         <pre><code>&lt;div role="toolbar" focusgroup="toolbar nomemory"
-     aria-label="Entry point demo"&gt;
+     aria-label="Entry point demo" class="toolbar-horizontal"&gt;
     &lt;button type="button"&gt;First&lt;/button&gt;
     &lt;button type="button" focusgroupstart&gt;Middle (Entry)&lt;/button&gt;
     &lt;button type="button"&gt;Last&lt;/button&gt;
@@ -206,8 +203,8 @@
       <details class="source-code">
         <summary>View source</summary>
         <pre><code>&lt;div role="toolbar" focusgroup="toolbar block"
-     aria-label="Vertical toolbar"
-     aria-orientation="vertical"&gt;
+     aria-label="Vertical toolbar" aria-orientation="vertical"
+     class="toolbar-vertical"&gt;
     &lt;button type="button"&gt;Cut&lt;/button&gt;
     &lt;button type="button"&gt;Copy&lt;/button&gt;
     &lt;button type="button"&gt;Paste&lt;/button&gt;

--- a/focusgroup/toolbar.html
+++ b/focusgroup/toolbar.html
@@ -37,7 +37,7 @@
       </div>
 
       <div class="demo-container">
-        <div role="toolbar" focusgroup="toolbar" aria-label="Text formatting" class="toolbar-horizontal">
+        <div focusgroup="toolbar" aria-label="Text formatting" class="toolbar-horizontal">
           <button type="button">Bold</button>
           <button type="button">Italic</button>
           <button type="button">Underline</button>
@@ -57,7 +57,7 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Text formatting" class="toolbar-horizontal"&gt;
+        <pre><code>&lt;div focusgroup="toolbar" aria-label="Text formatting" class="toolbar-horizontal"&gt;
     &lt;button type="button"&gt;Bold&lt;/button&gt;
     &lt;button type="button"&gt;Italic&lt;/button&gt;
     &lt;button type="button"&gt;Underline&lt;/button&gt;
@@ -87,7 +87,7 @@
       </div>
 
       <div class="demo-container">
-        <div role="toolbar" focusgroup="toolbar" aria-label="Document actions" class="toolbar-horizontal">
+        <div focusgroup="toolbar" aria-label="Document actions" class="toolbar-horizontal">
           <button type="button">New</button>
           <button type="button">Open</button>
           <button type="button">Save</button>
@@ -104,7 +104,7 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar"
+        <pre><code>&lt;div focusgroup="toolbar"
      aria-label="Document actions" class="toolbar-horizontal"&gt;
     &lt;button type="button"&gt;New&lt;/button&gt;
     &lt;button type="button"&gt;Open&lt;/button&gt;
@@ -136,7 +136,7 @@
       </div>
 
       <div class="demo-container">
-        <div role="toolbar" focusgroup="toolbar nomemory" aria-label="Entry point demo" class="toolbar-horizontal">
+        <div focusgroup="toolbar nomemory" aria-label="Entry point demo" class="toolbar-horizontal">
           <button type="button">First</button>
           <button type="button" focusgroupstart>Middle (Entry)</button>
           <button type="button">Last</button>
@@ -154,7 +154,7 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar nomemory"
+        <pre><code>&lt;div focusgroup="toolbar nomemory"
      aria-label="Entry point demo" class="toolbar-horizontal"&gt;
     &lt;button type="button"&gt;First&lt;/button&gt;
     &lt;button type="button" focusgroupstart&gt;Middle (Entry)&lt;/button&gt;
@@ -172,7 +172,7 @@
         <code>block</code> modifier overrides <code>toolbar</code>'s
         default <code>inline</code>, so only Up/Down arrow keys navigate.
         Set <code>aria-orientation="vertical"</code> on the
-        <code>role="toolbar"</code> element so assistive technologies know
+        container so assistive technologies know
         the toolbar is oriented vertically.</p>
       <div class="attr-label">focusgroup="toolbar block"</div>
 
@@ -182,7 +182,7 @@
       </div>
 
       <div class="demo-container">
-        <div role="toolbar" focusgroup="toolbar block" aria-label="Vertical toolbar" aria-orientation="vertical"
+        <div focusgroup="toolbar block" aria-label="Vertical toolbar" aria-orientation="vertical"
           class="toolbar-vertical">
           <button type="button">Cut</button>
           <button type="button">Copy</button>
@@ -195,14 +195,14 @@
           block axis. <code>block</code> overrides <code>toolbar</code>'s
           default <code>inline</code> modifier.</li>
         <li>Left/Right arrow keys do nothing; only Up/Down navigate</li>
-        <li><code>aria-orientation="vertical"</code> on
-          <code>role="toolbar"</code> is required for correct ARIA
-          semantics</li>
+        <li><code>aria-orientation="vertical"</code> is required for
+          correct ARIA semantics (the <code>toolbar</code> token maps the
+          role automatically)</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div role="toolbar" focusgroup="toolbar block"
+        <pre><code>&lt;div focusgroup="toolbar block"
      aria-label="Vertical toolbar" aria-orientation="vertical"
      class="toolbar-vertical"&gt;
     &lt;button type="button"&gt;Cut&lt;/button&gt;

--- a/focusgroup/toolbar.html
+++ b/focusgroup/toolbar.html
@@ -31,7 +31,7 @@
       <div class="attr-label">focusgroup="toolbar"</div>
 
       <div class="try-it">
-        <strong>Try it:</strong> Click the first button, then press
+        <strong>Try it:</strong> Tab to the toolbar, then press
         <kbd>→</kbd> and <kbd>←</kbd> to navigate. Press
         <kbd>Tab</kbd> to exit the toolbar.
       </div>
@@ -132,10 +132,10 @@
       <div class="attr-label">focusgroup="toolbar nomemory"</div>
 
       <div class="try-it">
-        <strong>Try it:</strong> Press <kbd>Tab</kbd> to enter. Notice
-        focus lands on "Middle (Entry)", not "First". The
-        <code>nomemory</code> makes it always return to
-        this entry point.
+        <strong>Try it:</strong> Press <kbd>Tab</kbd> to enter. Focus
+        lands on "Middle (Entry)" because <code>focusgroupstart</code>
+        marks it as the entry point. With <code>nomemory</code>,
+        focus returns here every time — not just on the first visit.
       </div>
 
       <div class="demo-container">

--- a/focusgroup/toolbar.html
+++ b/focusgroup/toolbar.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Focusgroup: Toolbar Pattern</title>
   <link rel="icon" type="image/png" href="https://edgestatic.azureedge.net/welcome/static/favicon.png">
@@ -13,7 +12,7 @@
 <body>
   <header class="page-header">
     <h1>Toolbar Pattern</h1>
-    <p>Arrow-key navigation for toolbar controls — the most common
+    <p>Arrow-key navigation for toolbar controls is the most common
       <code>focusgroup</code> use case.
     </p>
     <nav><a href="index.html">← All Demos</a></nav>
@@ -26,10 +25,10 @@
     <!-- ============================================================ -->
     <section class="demo-section">
       <h2 id="basic-toolbar">Basic Toolbar</h2>
-      <p>A simple horizontal toolbar. All buttons are natively focusable
-        — <code>focusgroup</code> makes the group a single tab stop
+      <p>A simple horizontal toolbar. All buttons are natively focusable.
+        <code>focusgroup</code> makes the group a single tab stop
         with arrow-key navigation.</p>
-      <div class="attr-label">focusgroup="toolbar inline"</div>
+      <div class="attr-label">focusgroup="toolbar"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Click the first button, then press
@@ -38,7 +37,7 @@
       </div>
 
       <div class="demo-container">
-        <div focusgroup="toolbar inline" aria-label="Text formatting" class="toolbar-horizontal">
+        <div role="toolbar" focusgroup="toolbar" aria-label="Text formatting" class="toolbar-horizontal">
           <button type="button">Bold</button>
           <button type="button">Italic</button>
           <button type="button">Underline</button>
@@ -47,17 +46,20 @@
       </div>
 
       <ul class="notice-list">
-        <li>The toolbar is <strong>one tab stop</strong> — Tab enters,
-          arrows navigate within, Tab exits</li>
+        <li>The toolbar is <strong>a single tab stop</strong>. Tab enters,
+          arrows navigate within, and Tab exits.</li>
         <li>Left/Right arrows move focus between buttons</li>
-        <li><code>inline</code> restricts navigation to the horizontal
-          axis</li>
+        <li><code>toolbar</code> defaults to horizontal (inline) navigation. No explicit <code>inline</code> modifier needed.</li>
         <li>No JavaScript is needed for focus management</li>
+        <li><strong>Note:</strong> Home and End keys for jumping to the
+          first/last item are <strong>not</strong> handled by
+          <code>focusgroup</code>. Add JavaScript handlers if your
+          toolbar requires them.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="toolbar inline" aria-label="Text
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar" aria-label="Text
      formatting"&gt;
     &lt;button type="button"&gt;Bold&lt;/button&gt;
     &lt;button type="button"&gt;Italic&lt;/button&gt;
@@ -74,21 +76,21 @@
       <h2 id="no-tabindex-management-needed">No <code>tabindex</code> Management Needed</h2>
       <p>With <code>focusgroup</code>, you don't need to set or manage
         <code>tabindex</code> on any items. The browser automatically
-        collapses all focusable children into a single tab stop — no
+        collapses all focusable children into a single tab stop, with no
         JavaScript "roving tabindex" boilerplate required.
       </p>
-      <div class="attr-label">focusgroup="toolbar inline"</div>
+      <div class="attr-label">focusgroup="toolbar"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Press <kbd>Tab</kbd> to enter the
         toolbar. Only one button is reachable via Tab. Use arrows
         to move between buttons, then <kbd>Tab</kbd> to exit. Tab
-        back in — focus is restored to the last-focused button
+        back in. Focus is restored to the last-focused button
         (memory).
       </div>
 
       <div class="demo-container">
-        <div focusgroup="toolbar inline" aria-label="Document actions" class="toolbar-horizontal">
+        <div role="toolbar" focusgroup="toolbar" aria-label="Document actions" class="toolbar-horizontal">
           <button type="button">New</button>
           <button type="button">Open</button>
           <button type="button">Save</button>
@@ -98,17 +100,14 @@
 
       <ul class="notice-list">
         <li><code>focusgroup</code> <strong>collapses multiple tab
-            stops into one</strong> — no <code>tabindex="-1"</code>
+            stops into one</strong>. No <code>tabindex="-1"</code>
           needed</li>
-        <li>This replaces the traditional "roving tabindex" JavaScript
-          pattern entirely</li>
-        <li>Focus memory is preserved — Tab away, then Tab back to
-          return to the last-focused button</li>
+        <li>Focus memory is preserved. The last-focused button is restored on re-entry.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="toolbar inline"
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar"
      aria-label="Document actions"&gt;
     &lt;button type="button"&gt;New&lt;/button&gt;
     &lt;button type="button"&gt;Open&lt;/button&gt;
@@ -124,19 +123,23 @@
     <section class="demo-section">
       <h2 id="entry-point-with-focusgroupstart">Entry Point with <code>focusgroupstart</code></h2>
       <p>The <code>focusgroupstart</code> attribute marks which element
-        receives focus when you Tab into the group. Both Tab and
-        Shift+Tab land on this element.</p>
-      <div class="attr-label">focusgroup="toolbar inline no-memory"</div>
+        receives focus when Tab enters the group for the first time
+        (with no prior focus history). When <code>nomemory</code> is
+        set, Tab <em>always</em> re-enters at <code>focusgroupstart</code>.
+        Without <code>nomemory</code>, Tab re-enters at the last-focused
+        item (focus memory), so <code>focusgroupstart</code> only applies
+        on the very first visit.</p>
+      <div class="attr-label">focusgroup="toolbar nomemory"</div>
 
       <div class="try-it">
-        <strong>Try it:</strong> Press <kbd>Tab</kbd> to enter — notice
+        <strong>Try it:</strong> Press <kbd>Tab</kbd> to enter. Notice
         focus lands on "Middle (Entry)", not "First". The
-        <code>no-memory</code> token ensures it always returns to
+        <code>nomemory</code> makes it always return to
         this entry point.
       </div>
 
       <div class="demo-container">
-        <div focusgroup="toolbar inline no-memory" aria-label="Entry point demo" class="toolbar-horizontal">
+        <div role="toolbar" focusgroup="toolbar nomemory" aria-label="Entry point demo" class="toolbar-horizontal">
           <button type="button">First</button>
           <button type="button" focusgroupstart>Middle (Entry)</button>
           <button type="button">Last</button>
@@ -146,15 +149,15 @@
       <ul class="notice-list">
         <li><code>focusgroupstart</code> controls the entry point for
           the group</li>
-        <li><code>no-memory</code> means focus always returns to the
+        <li><code>nomemory</code> means focus always returns to the
           entry point, not the last-focused element</li>
-        <li>Without <code>no-memory</code>, the group remembers where
+        <li>Without <code>nomemory</code>, the group remembers where
           you were</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="toolbar inline no-memory"
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar nomemory"
      aria-label="Entry point demo"&gt;
     &lt;button type="button"&gt;First&lt;/button&gt;
     &lt;button type="button" focusgroupstart&gt;Middle (Entry)&lt;/button&gt;
@@ -168,9 +171,12 @@
     <!-- ============================================================ -->
     <section class="demo-section">
       <h2 id="vertical-toolbar">Vertical Toolbar</h2>
-      <p>Use <code>block</code> instead of <code>inline</code> to
-        restrict navigation to the vertical axis (Up/Down arrows
-        only).</p>
+      <p>Use <code>focusgroup="toolbar block"</code>. The explicit
+        <code>block</code> modifier overrides <code>toolbar</code>'s
+        default <code>inline</code>, so only Up/Down arrow keys navigate.
+        Set <code>aria-orientation="vertical"</code> on the
+        <code>role="toolbar"</code> element so assistive technologies know
+        the toolbar is oriented vertically.</p>
       <div class="attr-label">focusgroup="toolbar block"</div>
 
       <div class="try-it">
@@ -179,7 +185,7 @@
       </div>
 
       <div class="demo-container">
-        <div focusgroup="toolbar block" aria-label="Vertical toolbar" aria-orientation="vertical"
+        <div role="toolbar" focusgroup="toolbar block" aria-label="Vertical toolbar" aria-orientation="vertical"
           class="toolbar-vertical">
           <button type="button">Cut</button>
           <button type="button">Copy</button>
@@ -188,16 +194,18 @@
       </div>
 
       <ul class="notice-list">
-        <li><code>block</code> locks navigation to the vertical
-          axis</li>
-        <li>Only Up/Down arrows work — Left/Right are ignored</li>
-        <li>Pair with <code>aria-orientation="vertical"</code> for
-          screen reader compatibility</li>
+        <li><code>toolbar block</code> uses the toolbar behavior with the
+          block axis. <code>block</code> overrides <code>toolbar</code>'s
+          default <code>inline</code> modifier.</li>
+        <li>Left/Right arrow keys do nothing; only Up/Down navigate</li>
+        <li><code>aria-orientation="vertical"</code> on
+          <code>role="toolbar"</code> is required for correct ARIA
+          semantics</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="toolbar block"
+        <pre><code>&lt;div role="toolbar" focusgroup="toolbar block"
      aria-label="Vertical toolbar"
      aria-orientation="vertical"&gt;
     &lt;button type="button"&gt;Cut&lt;/button&gt;


### PR DESCRIPTION
Changes can be viewed in my folk of the demos, https://janewman.github.io/Demos/focusgroup/

* Updates match the latest version of the [explainer](https://open-ui.org/components/scoped-focusgroup.explainer/), updated last week with https://github.com/openui/open-ui/pull/1379. This includes
  * Default modifiers for most behaviors.
  * `no-memory` renamed to `nomemory`.
  *  New attribute `nowrap` to allow author control when the behavior has wrap by default.
  *  Buttons are also eligible for role inference when they participate in a focusgroup. 
*  Language used in explanations has been edited for clarity.
* Small updates to each example for usability and correctness.
