### PR TITLE
[focusgroup] Update modifier usage and explanations to match the latest defaults.

### DIFF
--- a/focusgroup/README.md
+++ b/focusgroup/README.md
@@ -20,6 +20,7 @@ Interactive demos for the HTML `focusgroup` attribute, which lets you add arrow-
 ## Learn more
 
 - [Focusgroup Explainer (Open UI)](https://open-ui.org/components/scoped-focusgroup.explainer/)
+- [Focusgroup polyfill (GitHub)](https://github.com/microsoft/polyfills/tree/main/packages/focusgroup) ([npm: `@microsoft/focusgroup-polyfill`](https://www.npmjs.com/package/@microsoft/focusgroup-polyfill))
 - [ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/)
 
 ## Requirements

--- a/focusgroup/index.html
+++ b/focusgroup/index.html
@@ -124,7 +124,7 @@
               <h3>Listbox</h3>
               <p>Selectable list with vertical navigation and
                 selection management.</p>
-              <span class="attr-label">focusgroup="listbox block"</span>
+              <span class="attr-label">focusgroup="listbox"</span>
             </a>
           </li>
           <li>

--- a/focusgroup/listbox.html
+++ b/focusgroup/listbox.html
@@ -30,7 +30,7 @@
         Click or press
         <kbd>Enter</kbd>/<kbd>Space</kbd> to select an item.
       </p>
-      <div class="attr-label">focusgroup="listbox block nomemory"</div>
+      <div class="attr-label">focusgroup="listbox nomemory"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>↓</kbd> and <kbd>↑</kbd> to
@@ -39,7 +39,7 @@
       </div>
 
       <div class="demo-container">
-        <div focusgroup="listbox block nomemory" aria-label="Favorite fruit" aria-multiselectable="false" class="listbox">
+        <div focusgroup="listbox nomemory" aria-label="Favorite fruit" aria-multiselectable="false" class="listbox">
           <div class="listbox-option selected" tabindex="0" aria-selected="true" focusgroupstart>Apple</div>
           <div class="listbox-option" tabindex="0" aria-selected="false">Banana</div>
           <div class="listbox-option" tabindex="0" aria-selected="false">Cherry</div>
@@ -69,14 +69,14 @@
           Give every option <code>tabindex="0"</code> so the browser can
           focus it. <code>focusgroup</code> collapses those tab stops into
           one. No manual <code>tabindex="-1"</code> management needed.</li>
-        <li><code>listbox</code> has no default axis modifier. The explicit
-          <code>block</code> here applies Up/Down arrow navigation.
-          Without it, no axis would be active.</li>
+        <li><code>listbox</code> defaults to <code>block</code> (Up/Down
+          navigation). Use explicit <code>inline</code> for horizontal
+          listboxes.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="listbox block nomemory"
+        <pre><code>&lt;div focusgroup="listbox nomemory"
      aria-label="Favorite fruit"
      aria-multiselectable="false" class="listbox"&gt;
     &lt;div class="listbox-option selected" tabindex="0"
@@ -106,7 +106,7 @@
       <h2 id="listbox-with-wrapping">Listbox with Wrapping</h2>
       <p>With <code>wrap</code>, navigation continues from the last item
         back to the first (and vice versa).</p>
-      <div class="attr-label">focusgroup="listbox block wrap nomemory"</div>
+      <div class="attr-label">focusgroup="listbox wrap nomemory"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Navigate to "Mango" (last item), then
@@ -114,7 +114,7 @@
       </div>
 
       <div class="demo-container">
-        <div focusgroup="listbox block wrap nomemory" aria-label="Tropical fruits" aria-multiselectable="false" class="listbox">
+        <div focusgroup="listbox wrap nomemory" aria-label="Tropical fruits" aria-multiselectable="false" class="listbox">
           <div class="listbox-option selected" tabindex="0" aria-selected="true" focusgroupstart>Avocado</div>
           <div class="listbox-option" tabindex="0" aria-selected="false">Coconut</div>
           <div class="listbox-option" tabindex="0" aria-selected="false">Guava</div>
@@ -135,7 +135,7 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="listbox block wrap nomemory"
+        <pre><code>&lt;div focusgroup="listbox wrap nomemory"
      aria-label="Tropical fruits"
      aria-multiselectable="false" class="listbox"&gt;
     &lt;div class="listbox-option selected" tabindex="0"

--- a/focusgroup/radiogroup.html
+++ b/focusgroup/radiogroup.html
@@ -37,7 +37,7 @@
         disable it and see how arrow keys move focus without selecting.
       </div>
 
-      <div class="attr-label">focusgroup="radiogroup block wrap nomemory"</div>
+      <div class="attr-label">focusgroup="radiogroup block nomemory"</div>
 
       <div class="demo-container">
         <div class="comparison">
@@ -58,7 +58,7 @@
               <span class="toggle-slider"></span>
               Selection follows focus
             </label>
-            <div focusgroup="radiogroup block wrap nomemory" aria-label="Favorite color" class="radio-group radio-group-column">
+            <div focusgroup="radiogroup block nomemory" aria-label="Favorite color" class="radio-group radio-group-column">
               <span aria-checked="true" tabindex="0" class="radio-option checked" focusgroupstart>Red</span>
               <span aria-checked="false" tabindex="0" class="radio-option">Green</span>
               <span aria-checked="false" tabindex="0" class="radio-option">Blue</span>
@@ -84,13 +84,11 @@
           This mode is shown for comparison only. It is non-conformant for
           <code>role="radio"</code>.
         </li>
-        <li><code>radiogroup</code> has no default axis modifier. Unlike
-          <code>menu</code> (which defaults to <code>block wrap</code>) or
-          <code>tablist</code> (which defaults to <code>inline wrap</code>),
-          you must explicitly add <code>block</code> or <code>inline</code>.
-          <code>block</code> here sets the navigation axis to Up/Down.
-          <code>wrap</code> matches native radio behavior, looping from last to first
-          and first to last.</li>
+        <li><code>radiogroup</code> defaults to <code>wrap</code> (matching
+          native radio behavior, looping from last to first and first to
+          last) but does not default an axis. Add explicit <code>block</code>
+          or <code>inline</code> to pick one; add <code>nowrap</code> to
+          disable wrapping.</li>
         <li>The <code>radiogroup</code> token maps <code>role="radiogroup"</code>
           on the container and infers <code>role="radio"</code> on each
           generic child (including <code>&lt;span&gt;</code>).</li>
@@ -105,7 +103,7 @@
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="radiogroup block wrap nomemory"
+        <pre><code>&lt;div focusgroup="radiogroup block nomemory"
      aria-label="Favorite color" class="radio-group radio-group-column"&gt;
     &lt;span aria-checked="true" tabindex="0"
           class="radio-option checked" focusgroupstart&gt;Red&lt;/span&gt;

--- a/focusgroup/tablist.html
+++ b/focusgroup/tablist.html
@@ -131,7 +131,7 @@
       <h2 id="vertical-tablist">Vertical Tablist</h2>
       <p>A vertical tablist using <code>block</code> axis for Up/Down
         arrow navigation.</p>
-      <div class="attr-label">focusgroup="tablist block wrap nomemory"</div>
+      <div class="attr-label">focusgroup="tablist block nomemory"</div>
 
       <div class="try-it">
         <strong>Try it:</strong> Use <kbd>↓</kbd> and <kbd>↑</kbd> to
@@ -142,7 +142,7 @@
 
       <div class="demo-container">
         <div class="tab-wrapper-vertical">
-          <div focusgroup="tablist block wrap nomemory" aria-orientation="vertical" aria-label="Settings"
+          <div focusgroup="tablist block nomemory" aria-orientation="vertical" aria-label="Settings"
             class="tablist-vertical">
             <button type="button" class="tab selected" aria-selected="true" aria-controls="vpanel-general"
               id="vtab-general" focusgroupstart>General</button>
@@ -171,18 +171,18 @@
       </div>
 
       <ul class="notice-list">
-        <li><code>block</code> overrides the default <code>inline wrap</code>. This demo
-          re-adds <code>wrap</code> explicitly to keep wrapping active on the
-          block axis, so Down from the last tab wraps to the first</li>
+        <li>Explicit <code>block</code> overrides the default axis of inline.
+          <code>wrap</code> applies from <code>tablist</code>'s
+          defaults. Add <code>nowrap</code> to disable.</li>
         <li>Pair with <code>aria-orientation="vertical"</code> for
           screen readers</li>
-        <li>Same <code>wrap</code>, <code>nomemory</code>, and JavaScript-managed <code>focusgroupstart</code> behavior
+        <li>Same wrap behavior, <code>nomemory</code>, and JavaScript-managed <code>focusgroupstart</code>
           as the horizontal version. JavaScript moves <code>focusgroupstart</code> to the selected tab on each selection.</li>
       </ul>
 
       <details class="source-code">
         <summary>View source</summary>
-        <pre><code>&lt;div focusgroup="tablist block wrap nomemory"
+        <pre><code>&lt;div focusgroup="tablist block nomemory"
      aria-orientation="vertical" aria-label="Settings" class="tablist-vertical"&gt;
     &lt;button type="button" class="tab selected"
             aria-selected="true" aria-controls="vpanel-general"


### PR DESCRIPTION
The explainer was updated with https://github.com/openui/open-ui/commit/c486440c4d1cd60390e78344941628843e5a76de
This change updates focsugroup usage to rely on those defaults, and as you can see in most cases, this results in just deleting the modifier. The chromium implementation has already been updated to match.