### PR TITLE
Fix contrast ratio in dark mode

### DIFF
--- a/pwa-install-element/style.css
+++ b/pwa-install-element/style.css
@@ -179,6 +179,12 @@ install:hover {
   justify-self: center;
 }
 
+@media (prefers-color-scheme: dark) {
+  .unsupported-message {
+    background: hsl(from var(--error) h s 15);
+  }
+}
+
 .unsupported-message p {
   margin: 0;
 }


### PR DESCRIPTION
Fix the contrast ratio of the warning box shown when `<install>` is unsupported in a user's browser