### PR TITLE
Add new CSS gap decorations demos and update playground

### DIFF
--- a/css-gap-decorations/README.md
+++ b/css-gap-decorations/README.md
@@ -30,21 +30,7 @@ This directory contains demos that showcase the use of [CSS Gap Decorations](htt
 <!-- ====================================================================== -->
 ## Try the feature
 
-To try the feature, follow these steps:
-
-1. Open a Chromium-based browser, such as Microsoft Edge or Chrome, and make sure the version is at least 139.
-
-1. In the browser, open a new tab and go to `about:flags`.
-
-   In Microsoft Edge, you end up at `edge://flags`.
-
-1. In the **Search flags** box, enter **Experimental Web Platform features**.
-
-1. Set the **Experimental Web Platform features** flag to **Enabled**.
-
-1. Click the **Restart** button.
-
-   The browser restarts, with the flag applied.
+CSS Gap Decorations is available by default in Chrome and Edge 149+. Just open any of the demos above in a supported browser.
 
 
 <!-- ====================================================================== -->

--- a/css-gap-decorations/README.md
+++ b/css-gap-decorations/README.md
@@ -13,6 +13,12 @@ This directory contains demos that showcase the use of [CSS Gap Decorations](htt
 * [Notebook](https://microsoftedge.github.io/Demos/css-gap-decorations/notebook.html) - `notebook.html`
 * [Personal site](https://microsoftedge.github.io/Demos/css-gap-decorations/personal-site.html) - `personal-site.html`
 * [The Daily Oddity](https://microsoftedge.github.io/Demos/css-gap-decorations/the-daily-oddity.html) - `the-daily-oddity.html`
+* [Article Grid](https://microsoftedge.github.io/Demos/css-gap-decorations/article-grid.html) - `article-grid.html`
+* [Calendar Week View](https://microsoftedge.github.io/Demos/css-gap-decorations/calendar-week.html) - `calendar-week.html`
+* [Dashboard Grid](https://microsoftedge.github.io/Demos/css-gap-decorations/dashboard-grid.html) - `dashboard-grid.html`
+* [Dynamic Items](https://microsoftedge.github.io/Demos/css-gap-decorations/dynamic-items.html) - `dynamic-items.html`
+* [Settings List](https://microsoftedge.github.io/Demos/css-gap-decorations/settings-list.html) - `settings-list.html`
+* [Split Screen](https://microsoftedge.github.io/Demos/css-gap-decorations/split-screen.html) - `split-screen.html`
 
 
 <!-- ====================================================================== -->

--- a/css-gap-decorations/article-grid.html
+++ b/css-gap-decorations/article-grid.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Article Grid - CSS Gap Decorations Demo</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,700;1,9..144,400&family=IBM+Plex+Sans:wght@300;400;500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #e8ddd0;
+    --text-primary: #2a2118;
+    --text-secondary: #5c4f42;
+    --text-muted: #8a7d70;
+    --accent: #b5432a;
+    --accent-soft: rgba(181, 67, 42, 0.1);
+    --code-bg: rgba(42, 33, 24, 0.06);
+    --font-display: "Fraunces", serif;
+    --font-body: "IBM Plex Sans", sans-serif;
+    --font-mono: "IBM Plex Mono", monospace;
+  }
+
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  html {
+    scrollbar-color: var(--text-primary) var(--bg);
+    background: var(--bg);
+    height: 100%;
+  }
+
+  body {
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    padding: 2.5rem 2rem 4rem;
+    min-height: 100%;
+    font-weight: 300;
+  }
+
+
+  pre.caption {
+    max-width: 700px;
+    margin: 0 auto 1.25rem;
+    background: var(--code-bg);
+    border-radius: 3px;
+    border-left: 3px solid var(--accent);
+    padding: 14px 18px;
+    overflow-x: auto;
+  }
+
+  pre.caption code {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    line-height: 1.7;
+    color: var(--text-secondary);
+  }
+
+  .controls {
+    max-width: 700px;
+    margin: 0 auto 2rem;
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  button {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 0.55em 1.1em;
+    border-radius: 2px;
+    border: 1px solid rgba(42, 33, 24, 0.2);
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+
+  button:hover {
+    background: rgba(42, 33, 24, 0.05);
+    border-color: rgba(42, 33, 24, 0.4);
+    color: var(--text-secondary);
+  }
+
+  button.active {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+
+  section {
+    display: grid;
+    width: min(100%, 700px);
+    margin-inline: auto;
+    gap: 2rem;
+
+    rule: 2px solid black;
+    rule-width: 2px;
+    rule-visibility-items: between;
+  }
+
+  @media (min-width: 600px) {
+    section {
+      width: auto;
+      max-width: 700px;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      column-rule-break: intersection;
+      column-rule-inset: 0;
+      row-rule-width: 0;
+    }
+
+    section article {
+      grid-template-rows: subgrid;
+      display: grid;
+      grid-row: auto / span 2;
+      gap: 2rem;
+      rule: 1px solid;
+    }
+
+    section article,
+    section {
+      rule-visibility-items: between;
+    }
+  }
+
+  article h2 {
+    font-family: var(--font-display);
+    font-size: 1.15rem;
+    font-weight: 700;
+    line-height: 1.25;
+    color: var(--text-primary);
+    letter-spacing: -0.01em;
+  }
+
+  article p {
+    font-family: var(--font-body);
+    font-size: 0.82rem;
+    font-weight: 300;
+    line-height: 1.65;
+    color: var(--text-secondary);
+  }
+</style>
+</head>
+<body>
+
+<pre class="caption" id="codeBox"><code>section {
+  rule: 2px solid black;
+  rule-width: 2px;
+  rule-visibility-items: between;
+}</code></pre>
+
+<div class="controls">
+  <button onclick="setVisibility('normal')">normal</button>
+  <button onclick="setVisibility('all')">all</button>
+  <button class="active" onclick="setVisibility('between')">between</button>
+  <button onclick="setVisibility('around')">around</button>
+</div>
+
+<section id="gallery">
+  <article>
+    <h2>Article title</h2>
+    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptas ipsa pariatur architecto autem nemo, omnis voluptatum est itaque voluptatibus, repudiandae ipsam eos, ea quibusdam recusandae dignissimos praesentium deserunt minima quis.</p>
+  </article>
+
+  <article>
+    <h2>Article title that is longer</h2>
+    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptas ipsa pariatur architecto autem nemo, omnis voluptatum est itaque voluptatibus, repudiandae ipsam eos, ea quibusdam recusandae dignissimos praesentium deserunt minima quis.</p>
+  </article>
+
+  <article>
+    <h2>Article title</h2>
+    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptas ipsa pariatur architecto autem nemo, omnis voluptatum est itaque voluptatibus, repudiandae ipsam eos, ea quibusdam recusandae dignissimos praesentium deserunt minima quis.</p>
+  </article>
+
+  <article>
+    <h2>Article title</h2>
+    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptas ipsa pariatur architecto autem nemo, omnis voluptatum est itaque voluptatibus, repudiandae ipsam eos, ea quibusdam recusandae dignissimos praesentium deserunt minima quis.</p>
+  </article>
+
+  <article>
+    <h2>Article title</h2>
+    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptas ipsa pariatur architecto autem nemo, omnis voluptatum est itaque voluptatibus, repudiandae ipsam eos, ea quibusdam recusandae dignissimos praesentium deserunt minima quis.</p>
+  </article>
+
+  <article>
+    <h2>Article title</h2>
+    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptas ipsa pariatur architecto autem nemo, omnis voluptatum est itaque voluptatibus, repudiandae ipsam eos, ea quibusdam recusandae dignissimos praesentium deserunt minima quis.</p>
+  </article>
+
+  <article>
+    <h2>Article title</h2>
+    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptas ipsa pariatur architecto autem nemo, omnis voluptatum est itaque voluptatibus, repudiandae ipsam eos, ea quibusdam recusandae dignissimos praesentium deserunt minima quis.</p>
+  </article>
+
+</section>
+
+<script>
+  function setVisibility(value) {
+    const section = document.getElementById("gallery");
+    section.style.setProperty("rule-visibility-items", value);
+    document.querySelectorAll("article").forEach(a => {
+      a.style.setProperty("rule-visibility-items", value);
+    });
+    document.querySelectorAll(".controls button").forEach(btn => {
+      btn.classList.toggle("active", btn.textContent === value);
+    });
+    document.getElementById("codeBox").innerHTML = `<code>section {
+  rule: 2px solid black;
+  rule-width: 2px;
+  rule-visibility-items: ${value};
+}</code>`;
+  }
+</script>
+
+</body>
+</html>

--- a/css-gap-decorations/calendar-week.html
+++ b/css-gap-decorations/calendar-week.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Calendar Week View with CSS Gap Decorations</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,600;1,9..40,400&family=JetBrains+Mono:wght@400&family=Source+Sans+3:wght@300;400&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #faf9f6;
+    --surface: #ffffff;
+    --border: #e8e4df;
+    --border-light: #f0ece7;
+    --text: #3d3832;
+    --text-muted: #a09890;
+    --text-secondary: #6b6460;
+    --header-bg: #f6f4f0;
+    --today-bg: #fef7ed;
+    --today-accent: #e8985a;
+
+    --event-coral: #fce8e4;
+    --event-coral-border: #e8937e;
+    --event-coral-text: #9c4a38;
+
+    --event-sage: #e8f0e4;
+    --event-sage-border: #8aba7c;
+    --event-sage-text: #3d6b32;
+
+    --event-lavender: #ede4f5;
+    --event-lavender-border: #a87ec8;
+    --event-lavender-text: #5e3a7a;
+
+    --event-sand: #f5edde;
+    --event-sand-border: #cba86a;
+    --event-sand-text: #7a6230;
+
+    --event-sky: #e2edf8;
+    --event-sky-border: #7aaad4;
+    --event-sky-text: #2e5a7e;
+  }
+
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  body {
+    font-family: "DM Sans", sans-serif;
+    background: var(--bg);
+    padding: 32px;
+    color: var(--text);
+  }
+
+  .caption {
+    max-width: 960px;
+    margin: 0 auto 16px;
+  }
+
+  pre.caption {
+    background: #2c2a24;
+    border-radius: 6px;
+    padding: 12px 16px;
+    overflow-x: auto;
+  }
+
+  pre.caption code {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12px;
+    line-height: 1.6;
+    color: #e8985a;
+  }
+
+  .calendar {
+    max-width: 960px;
+    margin: 0 auto;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.03);
+
+    display: grid;
+    grid-template-columns: 56px repeat(7, 1fr);
+    grid-template-rows: 40px repeat(20, 28px);
+
+    column-rule: 2px solid var(--border);
+
+    row-rule-width: 2px, 1px;
+    row-rule-style: solid, dashed;
+    row-rule-color: var(--border), var(--border-light);
+
+    row-rule-inset: 0 0 0 0;
+  }
+
+  /* Day headers */
+  .day-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+    background: var(--header-bg);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .day-header.today {
+    color: var(--today-accent);
+    background: var(--today-bg);
+  }
+
+  .time-corner {
+    background: var(--header-bg);
+    border-bottom: 1px solid var(--border);
+  }
+
+  /* Time labels */
+  .time-label {
+    grid-column: 1;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+    padding: 2px 8px 0;
+    font-family: "Source Sans 3", sans-serif;
+    font-size: 11px;
+    font-weight: 400;
+    color: var(--text-muted);
+  }
+
+  /* Calendar events */
+  .event {
+    border-radius: 6px;
+    padding: 5px 8px;
+    font-size: 11px;
+    line-height: 1.4;
+    overflow: hidden;
+    margin: 1px 3px;
+    border-left: 3px solid;
+  }
+
+  .event-title {
+    font-weight: 600;
+    display: block;
+  }
+
+  .event-time {
+    font-family: "Source Sans 3", sans-serif;
+    font-weight: 400;
+    font-size: 10px;
+    opacity: 0.7;
+  }
+
+  .event-coral {
+    background: var(--event-coral);
+    color: var(--event-coral-text);
+    border-left-color: var(--event-coral-border);
+  }
+
+  .event-sage {
+    background: var(--event-sage);
+    color: var(--event-sage-text);
+    border-left-color: var(--event-sage-border);
+  }
+
+  .event-lavender {
+    background: var(--event-lavender);
+    color: var(--event-lavender-text);
+    border-left-color: var(--event-lavender-border);
+  }
+
+  .event-sand {
+    background: var(--event-sand);
+    color: var(--event-sand-text);
+    border-left-color: var(--event-sand-border);
+  }
+
+  .event-sky {
+    background: var(--event-sky);
+    color: var(--event-sky-text);
+    border-left-color: var(--event-sky-border);
+  }
+</style>
+</head>
+<body>
+
+
+<pre class="caption"><code>.grid-calendar {
+  column-rule: 2px solid #e8e4df;
+  row-rule-width: 2px, 1px;
+  row-rule-style: solid, dashed;
+  row-rule-color: #e8e4df, #f0ece7;
+}</code></pre>
+
+<div class="calendar">
+  <!-- Row 1: header -->
+  <div class="time-corner"></div>
+  <div class="day-header">Mon</div>
+  <div class="day-header today">Tue</div>
+  <div class="day-header">Wed</div>
+  <div class="day-header">Thu</div>
+  <div class="day-header">Fri</div>
+  <div class="day-header">Sat</div>
+  <div class="day-header">Sun</div>
+
+  <!--
+    Time labels: 8 AM to 5 PM
+    Row 2 = 8:00, Row 3 = 8:30, Row 4 = 9:00, ...
+    Formula: row = 2 + (hour - 8) * 2
+  -->
+  <span class="time-label" style="grid-row: 2 / 4">8 AM</span>
+  <span class="time-label" style="grid-row: 4 / 6">9 AM</span>
+  <span class="time-label" style="grid-row: 6 / 8">10 AM</span>
+  <span class="time-label" style="grid-row: 8 / 10">11 AM</span>
+  <span class="time-label" style="grid-row: 10 / 12">12 PM</span>
+  <span class="time-label" style="grid-row: 12 / 14">1 PM</span>
+  <span class="time-label" style="grid-row: 14 / 16">2 PM</span>
+  <span class="time-label" style="grid-row: 16 / 18">3 PM</span>
+  <span class="time-label" style="grid-row: 18 / 20">4 PM</span>
+  <span class="time-label" style="grid-row: 20 / 22">5 PM</span>
+
+  <!-- Events -->
+
+  <!-- Mon: Team Standup 9:00-9:30 -->
+  <div class="event event-sky" style="grid-column: 2; grid-row: 4 / 5">
+    <span class="event-title">Team Standup</span>
+    <span class="event-time">9:00 &ndash; 9:30</span>
+  </div>
+
+  <!-- Tue: Design Review 10:00-11:30 (left half) -->
+  <div class="event event-sage" style="grid-column: 3; grid-row: 6 / 9; margin-right: 50%">
+    <span class="event-title">Design Review</span>
+    <span class="event-time">10:00 &ndash; 11:30</span>
+  </div>
+
+  <!-- Tue: API Sync 10:00-10:30 (right half, top) -->
+  <div class="event event-sky" style="grid-column: 3; grid-row: 6 / 7; margin-left: 50%">
+    <span class="event-title">API Sync</span>
+    <span class="event-time">10:00 &ndash; 10:30</span>
+  </div>
+
+  <!-- Tue: UX Check-in 10:30-11:30 (right half, bottom) -->
+  <div class="event event-coral" style="grid-column: 3; grid-row: 7 / 9; margin-left: 50%">
+    <span class="event-title">UX Check-in</span>
+    <span class="event-time">10:30 &ndash; 11:30</span>
+  </div>
+
+  <!-- Wed: Lunch 12:00-1:00 -->
+  <div class="event event-sand" style="grid-column: 4; grid-row: 10 / 12">
+    <span class="event-title">Lunch</span>
+    <span class="event-time">12:00 &ndash; 1:00</span>
+  </div>
+
+  <!-- Thu: Planning 2:00-3:30 (left third) -->
+  <div class="event event-lavender" style="grid-column: 5; grid-row: 14 / 17; margin-right: 66.66%">
+    <span class="event-title">Sprint Planning</span>
+    <span class="event-time">2:00 &ndash; 3:30</span>
+  </div>
+
+  <!-- Thu: Code Review 2:00-3:30 (middle third) -->
+  <div class="event event-sky" style="grid-column: 5; grid-row: 14 / 17; margin-left: 33.33%; margin-right: 33.33%">
+    <span class="event-title">Code Review</span>
+    <span class="event-time">2:00 &ndash; 3:30</span>
+  </div>
+
+  <!-- Thu: Retro 2:00-3:30 (right third) -->
+  <div class="event event-sand" style="grid-column: 5; grid-row: 14 / 17; margin-left: 66.66%">
+    <span class="event-title">Retro</span>
+    <span class="event-time">2:00 &ndash; 3:30</span>
+  </div>
+
+  <!-- Fri: 1:1 4:00-4:30 -->
+  <div class="event event-coral" style="grid-column: 6; grid-row: 18 / 19">
+    <span class="event-title">1:1 with Sarah</span>
+    <span class="event-time">4:00 &ndash; 4:30</span>
+  </div>
+</div>
+
+</body>
+</html>

--- a/css-gap-decorations/dashboard-grid.html
+++ b/css-gap-decorations/dashboard-grid.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dashboard Grid - CSS Gap Decorations Demo</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Outfit:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg-primary: #0f0f1a;
+    --bg-card: #1a1a2e;
+    --bg-card-hover: #1f1f35;
+    --border-card: #2a2a45;
+    --text-primary: #e0e0ec;
+    --text-label: #6b6b8d;
+    --text-detail: #4e4e6a;
+    --rule-default: #2a2a45;
+    --rule-hover: #3b82f6;
+    --accent-green: #34d399;
+    --accent-blue: #60a5fa;
+    --accent-amber: #fbbf24;
+    --accent-red: #f87171;
+    --accent-cyan: #22d3ee;
+    --accent-purple: #a78bfa;
+    --font-mono: "JetBrains Mono", monospace;
+    --font-sans: "Outfit", sans-serif;
+  }
+
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  body {
+    font-family: var(--font-sans);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    padding: 2.5rem 2rem;
+    min-height: 100vh;
+  }
+
+  .caption {
+    max-width: 940px;
+    margin: 0 auto 1.75rem;
+  }
+
+  pre.caption {
+    background: #252540;
+    border-radius: 6px;
+    padding: 12px 16px;
+    overflow-x: auto;
+  }
+
+  pre.caption code {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    line-height: 1.6;
+    color: var(--accent-blue);
+  }
+
+  .dashboard {
+    display: grid;
+    grid-template-columns: 1fr 1fr 280px;
+    gap: 1.25rem;
+    max-width: 940px;
+    margin: 0 auto;
+
+    /* Gap decoration properties */
+    column-rule-style: solid;
+    column-rule-color: var(--accent-amber), var(--accent-green);
+    column-rule-width: 1px, 3px;
+    row-rule: 1px solid #1e1e36;
+    column-rule-break: intersection;
+    rule-inset-cap: 0px;
+    rule-inset-junction: 10px;
+
+    transition: column-rule-color 0.4s ease, rule-inset-junction 0.4s ease;
+  }
+
+  .dashboard:hover {
+    column-rule-color: #3b82f6, #3b82f6;
+    rule-inset-junction: 0px;
+  }
+
+  .card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-card);
+    border-radius: 6px;
+    padding: 1.25rem 1.35rem;
+    transition: background 0.2s ease, border-color 0.2s ease;
+  }
+
+  .card:hover {
+    background: var(--bg-card-hover);
+    border-color: #35355a;
+  }
+
+  .card h3 {
+    font-family: var(--font-sans);
+    font-size: 0.65rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-label);
+    margin-bottom: 0.6rem;
+  }
+
+  .metric-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  .card .metric {
+    font-family: var(--font-mono);
+    font-size: 1.65rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    letter-spacing: -0.02em;
+    line-height: 1;
+  }
+
+  .trend {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 400;
+    padding: 0.15em 0.4em;
+    border-radius: 3px;
+  }
+
+  .trend::before {
+    content: "";
+    display: inline-block;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+  }
+
+  .trend.up {
+    color: var(--accent-green);
+    background: rgba(52, 211, 153, 0.1);
+  }
+  .trend.up::before {
+    background: var(--accent-green);
+    box-shadow: 0 0 4px var(--accent-green);
+  }
+
+  .trend.down {
+    color: var(--accent-red);
+    background: rgba(248, 113, 113, 0.1);
+  }
+  .trend.down::before {
+    background: var(--accent-red);
+    box-shadow: 0 0 4px var(--accent-red);
+  }
+
+  .trend.flat {
+    color: var(--text-label);
+    background: rgba(107, 107, 141, 0.1);
+  }
+  .trend.flat::before {
+    background: var(--text-label);
+  }
+
+  .card .detail {
+    font-size: 0.72rem;
+    color: var(--text-detail);
+    margin-top: 0.45rem;
+    line-height: 1.4;
+  }
+
+  .card {
+    border-left: none;
+  }
+</style>
+</head>
+<body>
+
+
+<pre class="caption"><code>.grid-dashboard {
+  gap: 1.25rem;
+  column-rule-width: 1px, 3px;
+  column-rule-style: solid;
+  column-rule-color: #fbbf24, #34d399;
+  column-rule-break: intersection;
+  row-rule: 1px solid #1e1e36;
+  rule-inset-cap: 0px;
+  rule-inset-junction: 10px;
+  transition: column-rule-color 0.4s,
+              rule-inset-junction 0.4s;
+}
+.grid-dashboard:hover {
+  column-rule-color: #3b82f6, #3b82f6;
+  rule-inset-junction: 0px;
+}</code></pre>
+
+<div class="dashboard">
+  <div class="card">
+    <h3>Revenue</h3>
+    <div class="metric-row">
+      <div class="metric">$48,200</div>
+      <span class="trend up">+12%</span>
+    </div>
+    <div class="detail">May 2026, before adjustments</div>
+  </div>
+
+  <div class="card">
+    <h3>Active Users</h3>
+    <div class="metric-row">
+      <div class="metric">3,812</div>
+      <span class="trend up">+8%</span>
+    </div>
+    <div class="detail">Logged in within the last 7 days</div>
+  </div>
+
+  <div class="card">
+    <h3>Server Load</h3>
+    <div class="metric-row">
+      <div class="metric">42%</div>
+      <span class="trend down">+6pt</span>
+    </div>
+    <div class="detail">Average across 6 regions</div>
+  </div>
+
+  <div class="card">
+    <h3>Orders</h3>
+    <div class="metric-row">
+      <div class="metric">1,204</div>
+      <span class="trend up">+3%</span>
+    </div>
+    <div class="detail">Placed this month</div>
+  </div>
+
+  <div class="card">
+    <h3>Bounce Rate</h3>
+    <div class="metric-row">
+      <div class="metric">28.5%</div>
+      <span class="trend up">-5.5pt</span>
+    </div>
+    <div class="detail">Down from 34% in April</div>
+  </div>
+
+  <div class="card">
+    <h3>Uptime</h3>
+    <div class="metric-row">
+      <div class="metric">99.97%</div>
+      <span class="trend flat">0%</span>
+    </div>
+    <div class="detail">Last 30 days</div>
+  </div>
+
+  <div class="card">
+    <h3>Support Tickets</h3>
+    <div class="metric-row">
+      <div class="metric">37</div>
+      <span class="trend up">-14</span>
+    </div>
+    <div class="detail">12 open, 25 resolved</div>
+  </div>
+
+  <div class="card">
+    <h3>Conversion</h3>
+    <div class="metric-row">
+      <div class="metric">4.1%</div>
+      <span class="trend up">+0.3pt</span>
+    </div>
+    <div class="detail">Checkout completion rate</div>
+  </div>
+
+  <div class="card">
+    <h3>Disk Usage</h3>
+    <div class="metric-row">
+      <div class="metric">218 GB</div>
+      <span class="trend down">+22 GB</span>
+    </div>
+    <div class="detail">of 500 GB provisioned</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/css-gap-decorations/dynamic-items.html
+++ b/css-gap-decorations/dynamic-items.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dynamic Items - CSS Gap Decorations Demo</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Outfit:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg-primary: #0f0f1a;
+    --bg-chip: #1a1a2e;
+    --bg-chip-hover: #1f1f35;
+    --border-chip: #2a2a45;
+    --text-primary: #e0e0ec;
+    --text-label: #6b6b8d;
+    --rule-color: #2a2a45;
+    --accent-blue: #60a5fa;
+    --accent-green: #34d399;
+    --accent-purple: #a78bfa;
+    --font-mono: "JetBrains Mono", monospace;
+    --font-sans: "Outfit", sans-serif;
+  }
+
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  body {
+    font-family: var(--font-sans);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    padding: 2.5rem 2rem;
+    min-height: 100vh;
+  }
+
+  .caption {
+    max-width: 720px;
+    margin: 0 auto 1.75rem;
+  }
+
+  pre.caption {
+    background: #252540;
+    border-radius: 6px;
+    padding: 12px 16px;
+    overflow-x: auto;
+  }
+
+  pre.caption code {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    line-height: 1.6;
+    color: var(--accent-blue);
+  }
+
+  .controls {
+    max-width: 720px;
+    margin: 0 auto 1.25rem;
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  button {
+    font-family: var(--font-sans);
+    font-size: 0.78rem;
+    font-weight: 500;
+    padding: 0.5em 1.1em;
+    border-radius: 5px;
+    border: 1px solid var(--border-chip);
+    background: var(--bg-chip);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+
+  button:hover {
+    background: var(--bg-chip-hover);
+    border-color: #35355a;
+  }
+
+  button.add {
+    border-color: var(--accent-blue);
+    background: rgba(96, 165, 250, 0.1);
+  }
+
+  button.add:hover {
+    background: rgba(96, 165, 250, 0.18);
+  }
+
+  .container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    max-width: 720px;
+    margin: 0 auto;
+
+    column-rule: 1px solid var(--rule-color);
+    column-rule-color: var(--accent-blue), var(--accent-green), var(--accent-purple);
+    rule-inset: 5px;
+    row-rule: 1px solid var(--rule-color);
+  }
+
+  .chip {
+    min-width: 120px;
+    padding: 0.75rem 1.25rem;
+    background: var(--bg-chip);
+    border: 1px solid var(--border-chip);
+    border-radius: 1px;
+    font-size: 0.88rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    transition: background 0.15s ease, border-color 0.15s ease;
+    white-space: nowrap;
+  }
+
+  .chip:hover {
+    background: var(--bg-chip-hover);
+    border-color: #35355a;
+    cursor: pointer;
+  }
+
+  .slider-row {
+    max-width: 720px;
+    margin: 0 auto 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.78rem;
+    color: var(--text-label);
+  }
+
+  .slider-row input[type="range"] {
+    flex: 1;
+    accent-color: var(--accent-blue);
+  }
+</style>
+</head>
+<body>
+
+<pre class="caption"><code>.flex-tags {
+  gap: 16px;
+  column-rule: 1px solid #2a2a45;
+  column-rule-color: #60a5fa, #34d399, #a78bfa;
+  rule-inset: 5px;
+  row-rule: 1px solid #2a2a45;
+}</code></pre>
+
+<div class="controls">
+  <button class="add" onclick="addItem()">Add item</button>
+  <button onclick="resetItems()">Reset</button>
+</div>
+
+<div class="slider-row">
+  <span>Container width</span>
+  <input type="range" min="200" max="720" value="720" oninput="resizeContainer(this.value)">
+</div>
+
+<div class="container" id="container"></div>
+
+<script>
+  const labels = [
+    "TypeScript", "Rust", "WebAssembly", "GraphQL", "Postgres",
+    "Redis", "Docker", "Kubernetes", "Terraform", "Go",
+    "Swift", "Kotlin", "Zig", "Svelte", "Deno",
+    "SQLite", "gRPC", "Protobuf", "NGINX", "Caddy",
+    "Vite", "esbuild", "Bun", "Astro", "HTMX"
+  ];
+
+  const initial = ["TypeScript", "Rust", "WebAssembly", "GraphQL", "Postgres", "Redis", "Docker", "Kubernetes", "Terraform", "Go", "Swift"];
+  let index = initial.length;
+
+  function createChip(text) {
+    const el = document.createElement("div");
+    el.className = "chip";
+    el.textContent = text;
+    el.addEventListener("click", () => el.remove());
+    return el;
+  }
+
+  function addItem() {
+    const container = document.getElementById("container");
+    container.appendChild(createChip(labels[index % labels.length]));
+    index++;
+  }
+
+  function resetItems() {
+    const container = document.getElementById("container");
+    container.innerHTML = "";
+    index = initial.length;
+    initial.forEach(label => container.appendChild(createChip(label)));
+  }
+
+  function resizeContainer(val) {
+    document.getElementById("container").style.maxWidth = val + "px";
+  }
+
+  resetItems();
+</script>
+
+</body>
+</html>

--- a/css-gap-decorations/notebook.html
+++ b/css-gap-decorations/notebook.html
@@ -26,7 +26,7 @@
       
       rule-overlap: column-over-row;
       column-rule: solid black 1.5px;
-      column-rule-break: spanning-item;
+      column-rule-break: normal;
       row-rule:
         /* header lines */
         repeat(3, 0),

--- a/css-gap-decorations/playground.html
+++ b/css-gap-decorations/playground.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CSS Gap Decorations playground</title>
+  <title>Interactive Playground — CSS Gap Decorations</title>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet" />
   <style>
     :root {
@@ -17,13 +16,7 @@
       --flex-row-rule-color: crimson;
       --flex-col-rule-color: teal;
     }
-
-    *,
-    *::before,
-    *::after {
-      box-sizing: border-box;
-    }
-
+    *, *::before, *::after { box-sizing: border-box; }
     body {
       margin: 0;
       font-family: 'Montserrat', sans-serif;
@@ -31,45 +24,39 @@
       color: var(--primary);
       line-height: 1.6;
     }
-
     header {
       text-align: center;
       padding: 2rem 1rem;
       background: var(--secondary);
       color: #fff;
     }
-
     header h1 {
       margin: 0;
       font-size: 2.5rem;
       letter-spacing: 1px;
     }
-
     .intro {
       max-width: 800px;
       margin: 1.5rem auto;
       padding: 1rem 1.5rem;
       background: var(--card-bg);
       border-radius: 6px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
       font-size: 1rem;
     }
-
     .intro a {
       color: var(--secondary);
       text-decoration: none;
       font-weight: 600;
     }
-
     section {
       width: 95%;
       margin: 3rem auto;
       padding: 2rem;
       background: var(--card-bg);
       border-radius: 8px;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     }
-
     h2 {
       text-align: center;
       font-size: 1.75rem;
@@ -77,7 +64,6 @@
       color: var(--accent);
       position: relative;
     }
-
     h2::after {
       content: '';
       display: block;
@@ -86,68 +72,43 @@
       background: var(--secondary);
       margin: 0.5rem auto 0;
     }
-
     .demo-group {
       display: flex;
       gap: 2rem;
       margin-bottom: 4rem;
     }
-
-    .demo-group>.controls {
-      flex: 1;
-    }
-
-    .demo-group>.preview {
-      flex: 2;
-      padding: 0 1rem;
-    }
-
+    .demo-group > .controls { flex: 1; }
+    .demo-group > .preview { flex: 2; padding: 0 1rem; }
     .controls {
       background: var(--light-bg);
       padding: 1rem;
       border-radius: 6px;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
       font-size: 0.9rem;
     }
-
-    .controls label {
-      display: block;
-      margin: 0.5rem 0 0.25rem;
-      font-weight: 600;
-    }
-
-    .controls input[type=range],
-    .controls select {
-      width: 100%;
-      margin-bottom: 0.75rem;
-    }
+    .controls label { display: block; margin: 0.5rem 0 0.25rem; font-weight: 600; }
+    .controls input[type=range], .controls select { width: 100%; margin-bottom: 0.75rem; }
 
     /* Multicolumn Preview */
     .multicol {
       column-count: 3;
-      column-wrap: wrap;
       column-gap: 30px;
       column-rule-width: 2px;
       column-rule-style: solid;
       column-rule-color: #555;
-      column-rule-inset: 0;
+      column-rule-inset: 0px;
       row-rule-width: 2px;
       row-rule-style: dashed;
       row-rule-color: #888;
-      row-rule-inset: 0;
+      row-rule-inset: 0px;
       rule-overlap: column-over-row;
     }
-
     .multicol h3 {
       font-size: 1.25rem;
       margin-bottom: 0.75em;
       color: var(--secondary);
     }
-
-    .multicol p {
-      margin: 0 0 1.2em;
-    }
-
+    .multicol p { margin: 0 0 1.2em; }
     .multicol blockquote {
       margin: 1em 0;
       padding: 0.75em 1em;
@@ -155,11 +116,7 @@
       background: #f9f9f9;
       font-style: italic;
     }
-
-    .multicol ul {
-      margin: 0 0 1.2em;
-      padding-left: 1.2em;
-    }
+    .multicol ul { margin: 0 0 1.2em; padding-left: 1.2em; }
 
     /* Flex Preview */
     .flex-container {
@@ -169,36 +126,25 @@
       row-rule-width: 4px;
       row-rule-style: dotted;
       row-rule-color: var(--flex-row-rule-color);
-      row-rule-inset: 0;
+      row-rule-inset: 0px;
       column-rule-width: 4px;
       column-rule-style: dotted;
       column-rule-color: var(--flex-col-rule-color);
-      column-rule-inset: 0;
+      column-rule-inset: 0px;
       rule-overlap: row-over-column;
     }
-
     .flex-item {
       background: var(--card-bg);
       padding: 1.5rem;
       border-radius: 6px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
       transition: transform 0.3s ease, box-shadow 0.3s ease;
       text-align: center;
       font-weight: 600;
     }
-
-    .flex-item:hover {
-      transform: translateY(-5px);
-      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
-    }
-
-    .flex-item.wide {
-      flex: 2 1 calc(60% - 20px);
-    }
-
-    .flex-item.medium {
-      flex: 1 1 calc(30% - 20px);
-    }
+    .flex-item:hover { transform: translateY(-5px); box-shadow: 0 6px 16px rgba(0,0,0,0.15); }
+    .flex-item.wide { flex: 2 1 calc(60% - 20px); }
+    .flex-item.medium { flex: 1 1 calc(30% - 20px); }
 
     /* Grid Preview */
     .grid {
@@ -208,110 +154,110 @@
       row-rule-width: 3px;
       row-rule-style: solid;
       row-rule-color: var(--accent);
-      row-rule-inset: 0;
+      row-rule-inset: 0px;
       column-rule-width: 3px;
       column-rule-style: solid;
       column-rule-color: var(--grid-rule-color);
-      column-rule-inset: 0;
+      column-rule-inset: 0px;
       rule-overlap: row-over-column;
     }
-
     .grid-item {
       background: var(--card-bg);
       padding: 1.5rem;
       border-radius: 6px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
       text-align: center;
       font-weight: 600;
       transition: transform 0.3s ease, box-shadow 0.3s ease;
     }
+    .grid-item:hover { transform: translateY(-5px); box-shadow: 0 6px 16px rgba(0,0,0,0.15); }
+    .grid-item.spanner { grid-column: span 2; grid-row: span 2; }
 
-    .grid-item:hover {
-      transform: translateY(-5px);
-      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
-    }
-
-    .grid-item.spanner {
-      grid-column: span 2;
-      grid-row: span 2;
-    }
-
-    footer {
-      text-align: center;
-      padding: 1rem;
-      font-size: 0.9rem;
-      color: #777;
-    }
+    footer { text-align: center; padding: 1rem; font-size: 0.9rem; color: #777; }
   </style>
 </head>
-
 <body>
   <header>
-    <h1>CSS Gap Decorations playground</h1>
+    <h1>CSS Gap Decorations Demo</h1>
   </header>
   <div class="intro">
-    <p>This interactive demo showcases the features of the <a href="https://drafts.csswg.org/css-gaps-1/"
-        target="_blank">
-        CSS Gaps Decorations Module Level 1</a>.
-      Use the controls to tweak gap, rule, and overlap properties in real time
-      and see how they affect <a href="#grid">grid</a>, <a href="#flex">flex</a>, and <a href="#multicolumn">multicolumn</a> layouts.
+    <p>This interactive demo showcases the features of the <a href="https://www.w3.org/TR/css-gaps-1/" target="_blank">
+      CSS Gaps Decorations Module Level 1</a>.
+      Use the controls to tweak gap, rule, and rule-overlap properties in real time
+      and see how they affect multicolumn, flex, and grid layouts.
     </p>
     <p>
-      This is a non-exhaustive demo. See the spec for full details on the properties and their values.
-    </p>
-    <p>
-      As of right now, this is only implemented for Chromium-based browsers, and 
-      the "Experimental Web Platform features" flag is needed to enable the feature:<br/>
-      <code>--enable-features=enable-experimental-web-platform-features</code>
+       This is a non-exhaustive demo. See the spec for full details on the properties and their values.
     </p>
   </div>
 
   <section>
-    <h2 id="grid">Grid Layout</h2>
+    <h2>Grid Layout</h2>
     <div class="demo-group">
       <aside class="controls" data-target=".grid">
         <label>Gap (px): <output id="grGapVal">30</output></label>
-        <input type="range" min="0" max="100" value="30" data-prop="gap" data-unit="px"
-          oninput="grGapVal.value=this.value" />
+        <input type="range" min="0" max="100" value="30" data-prop="gap" data-unit="px" oninput="grGapVal.value=this.value"/>
         <label>Row-rule-width (px): <output id="grRowRuleWVal">3</output></label>
-        <input type="range" min="0" max="20" value="3" data-prop="row-rule-width" data-unit="px"
-          oninput="grRowRuleWVal.value=this.value" />
-        <label>Row-rule-inset (%): <output id="grRowRuleOVal">0</output>%</label>
-        <input type="range" min="0" max="100" value="0" data-prop="row-rule-inset" data-unit="%"
-          oninput="grRowRuleOVal.value=this.value" />
+        <input type="range" min="0" max="20" value="3" data-prop="row-rule-width" data-unit="px" oninput="grRowRuleWVal.value=this.value"/>
+        <label>Row-rule-inset (px): <output id="grRowRuleOVal">0</output></label>
+        <input type="range" min="-50" max="50" value="0" data-prop="row-rule-inset" data-unit="px" oninput="grRowRuleOVal.value=this.value"/>
         <label>Row-rule-style:</label>
         <select data-prop="row-rule-style">
-          <option value="solid">solid</option>
+          <option value="none">none</option>
+          <option value="hidden">hidden</option>
+          <option value="solid" selected>solid</option>
           <option value="dashed">dashed</option>
           <option value="dotted">dotted</option>
+          <option value="double">double</option>
+          <option value="groove">groove</option>
+          <option value="ridge">ridge</option>
+          <option value="inset">inset</option>
+          <option value="outset">outset</option>
         </select>
         <label>Row-rule-color:</label>
         <input type="color" class="color-picker" data-prop="row-rule-color" value="#888888" />
         <label>Row-rule-break:</label>
         <select data-prop="row-rule-break">
+          <option value="normal">normal</option>
           <option value="none">none</option>
           <option value="intersection">intersection</option>
-          <option value="spanning-item">spanning-item</option>
         </select>
         <label>Column-rule-width (px): <output id="grColRuleWVal">3</output></label>
-        <input type="range" min="0" max="20" value="3" data-prop="column-rule-width" data-unit="px"
-          oninput="grColRuleWVal.value=this.value" />
+        <input type="range" min="0" max="20" value="3" data-prop="column-rule-width" data-unit="px" oninput="grColRuleWVal.value=this.value"/>
         <label>Column-rule-inset (px): <output id="grColRuleOVal">0</output></label>
-        <input type="range" min="-50" max="50" value="0" data-prop="column-rule-inset" data-unit="px"
-          oninput="grColRuleOVal.value=this.value" />
+        <input type="range" min="-50" max="50" value="0" data-prop="column-rule-inset" data-unit="px" oninput="grColRuleOVal.value=this.value"/>
         <label>Column-rule-style:</label>
         <select data-prop="column-rule-style">
-          <option value="solid">solid</option>
+          <option value="none">none</option>
+          <option value="hidden">hidden</option>
+          <option value="solid" selected>solid</option>
           <option value="dashed">dashed</option>
           <option value="dotted">dotted</option>
+          <option value="double">double</option>
+          <option value="groove">groove</option>
+          <option value="ridge">ridge</option>
+          <option value="inset">inset</option>
+          <option value="outset">outset</option>
         </select>
         <label>Column-rule-color:</label>
         <input type="color" class="color-picker" data-prop="column-rule-color" value="#888888" />
         <label>Column-rule-break:</label>
         <select data-prop="column-rule-break">
+          <option value="normal">normal</option>
           <option value="none">none</option>
           <option value="intersection">intersection</option>
-          <option value="spanning-item">spanning-item</option>
+        </select>
+        <label>Row-rule-visibility-items:</label>
+        <select data-prop="row-rule-visibility-items">
+          <option value="all">all</option>
+          <option value="around">around</option>
+          <option value="between">between</option>
+        </select>
+        <label>Column-rule-visibility-items:</label>
+        <select data-prop="column-rule-visibility-items">
+          <option value="all">all</option>
+          <option value="around">around</option>
+          <option value="between">between</option>
         </select>
         <label>Rule-overlap:</label>
         <select data-prop="rule-overlap">
@@ -335,52 +281,61 @@
     </div>
   </section>
 
-  <section>
-    <h2 id="flex">Flex Layout</h2>
+    <section>
+    <h2>Flex Layout</h2>
     <div class="demo-group">
       <aside class="controls" data-target=".flex-container">
         <label>Gap (px): <output id="fxGapVal">20</output></label>
-        <input type="range" min="0" max="100" value="20" data-prop="gap" data-unit="px"
-          oninput="fxGapVal.value=this.value" />
+        <input type="range" min="0" max="100" value="20" data-prop="gap" data-unit="px" oninput="fxGapVal.value=this.value"/>
         <label>Row-rule-width (px): <output id="fxRowRuleWVal">4</output></label>
-        <input type="range" min="0" max="20" value="4" data-prop="row-rule-width" data-unit="px"
-          oninput="fxRowRuleWVal.value=this.value" />
-        <label>Row-rule-inset (%): <output id="fxRowRuleOVal">0</output>%</label>
-        <input type="range" min="0" max="100" value="0" data-prop="row-rule-inset" data-unit="%"
-          oninput="fxRowRuleOVal.value=this.value" />
+        <input type="range" min="0" max="20" value="4" data-prop="row-rule-width" data-unit="px" oninput="fxRowRuleWVal.value=this.value"/>
+        <label>Row-rule-inset (px): <output id="fxRowRuleOVal">0</output></label>
+        <input type="range" min="-50" max="50" value="0" data-prop="row-rule-inset" data-unit="px" oninput="fxRowRuleOVal.value=this.value"/>
         <label>Row-rule-style:</label>
         <select data-prop="row-rule-style">
+          <option value="none">none</option>
+          <option value="hidden">hidden</option>
           <option value="solid">solid</option>
           <option value="dashed">dashed</option>
-          <option value="dotted">dotted</option>
+          <option value="dotted" selected>dotted</option>
+          <option value="double">double</option>
+          <option value="groove">groove</option>
+          <option value="ridge">ridge</option>
+          <option value="inset">inset</option>
+          <option value="outset">outset</option>
         </select>
         <label>Row-rule-color:</label>
         <input type="color" class="color-picker" data-prop="row-rule-color" value="#888888" />
         <label>Column-rule-width (px): <output id="fxColRuleWVal">4</output></label>
-        <input type="range" min="0" max="20" value="4" data-prop="column-rule-width" data-unit="px"
-          oninput="fxColRuleWVal.value=this.value" />
+        <input type="range" min="0" max="20" value="4" data-prop="column-rule-width" data-unit="px" oninput="fxColRuleWVal.value=this.value"/>
         <label>Column-rule-inset (px): <output id="fxColRuleOVal">0</output></label>
-        <input type="range" min="-50" max="50" value="0" data-prop="column-rule-inset" data-unit="px"
-          oninput="fxColRuleOVal.value=this.value" />
+        <input type="range" min="-50" max="50" value="0" data-prop="column-rule-inset" data-unit="px" oninput="fxColRuleOVal.value=this.value"/>
         <label>Column-rule-style:</label>
         <select data-prop="column-rule-style">
+          <option value="none">none</option>
+          <option value="hidden">hidden</option>
           <option value="solid">solid</option>
           <option value="dashed">dashed</option>
-          <option value="dotted">dotted</option>
+          <option value="dotted" selected>dotted</option>
+          <option value="double">double</option>
+          <option value="groove">groove</option>
+          <option value="ridge">ridge</option>
+          <option value="inset">inset</option>
+          <option value="outset">outset</option>
         </select>
         <label>Column-rule-color:</label>
         <input type="color" class="color-picker" data-prop="column-rule-color" value="#888888" />
         <label>Row-rule-break:</label>
         <select data-prop="row-rule-break">
+          <option value="normal">normal</option>
           <option value="none">none</option>
           <option value="intersection">intersection</option>
-          <option value="spanning-item">spanning-item</option>
         </select>
         <label>Column-rule-break:</label>
         <select data-prop="column-rule-break">
+          <option value="normal">normal</option>
           <option value="none">none</option>
           <option value="intersection">intersection</option>
-          <option value="spanning-item">spanning-item</option>
         </select>
         <label>Rule-overlap:</label>
         <select data-prop="rule-overlap">
@@ -400,59 +355,60 @@
   </section>
 
   <section>
-    <h2 id="multicolumn">Multicolumn Layout</h2>
+    <h2>Multicolumn Layout</h2>
     <div class="demo-group">
       <aside class="controls">
         <label>Column-gap (px): <output id="mcColGapVal">30</output></label>
-        <input type="range" min="0" max="100" value="30" data-prop="column-gap" data-unit="px"
-          oninput="mcColGapVal.value=this.value" />
+        <input type="range" min="0" max="100" value="30" data-prop="column-gap" data-unit="px" oninput="mcColGapVal.value=this.value" />
         <label>Column-rule-width (px): <output id="mcColRuleWVal">2</output></label>
-        <input type="range" min="0" max="20" value="2" data-prop="column-rule-width" data-unit="px"
-          oninput="mcColRuleWVal.value=this.value" />
+        <input type="range" min="0" max="20" value="2" data-prop="column-rule-width" data-unit="px" oninput="mcColRuleWVal.value=this.value" />
         <label>Column-rule-inset (px): <output id="mcColRuleOVal">0</output></label>
-        <input type="range" min="-50" max="50" value="0" data-prop="column-rule-inset" data-unit="px"
-          oninput="mcColRuleOVal.value=this.value" />
+        <input type="range" min="-50" max="50" value="0" data-prop="column-rule-inset" data-unit="px" oninput="mcColRuleOVal.value=this.value"/>
         <label>Column-rule-style:</label>
         <select data-prop="column-rule-style">
-          <option value="solid">solid</option>
+          <option value="none">none</option>
+          <option value="hidden">hidden</option>
+          <option value="solid" selected>solid</option>
           <option value="dashed">dashed</option>
           <option value="dotted">dotted</option>
+          <option value="double">double</option>
+          <option value="groove">groove</option>
+          <option value="ridge">ridge</option>
+          <option value="inset">inset</option>
+          <option value="outset">outset</option>
         </select>
         <label>Column-rule-color:</label>
         <input type="color" class="color-picker" data-prop="column-rule-color" value="#888888" />
         <label>Column-rule-break:</label>
         <select data-prop="column-rule-break">
+          <option value="normal">normal</option>
           <option value="none">none</option>
           <option value="intersection">intersection</option>
-          <option value="spanning-item">spanning-item</option>
         </select>
         <label>Row-rule-width (px): <output id="mcRowRuleWVal">2</output></label>
-        <input type="range" min="0" max="20" value="2" data-prop="row-rule-width" data-unit="px"
-          oninput="mcRowRuleWVal.value=this.value" />
-        <label>Row-rule-inset (%): <output id="mcRowRuleOVal">0</output>%</label>
-        <input type="range" min="0" max="100" value="0" data-prop="row-rule-inset" data-unit="%"
-          oninput="mcRowRuleOVal.value=this.value" />
+        <input type="range" min="0" max="20" value="2" data-prop="row-rule-width" data-unit="px" oninput="mcRowRuleWVal.value=this.value" />
+        <label>Row-rule-inset (px): <output id="mcRowRuleOVal">0</output></label>
+        <input type="range" min="-50" max="50" value="0" data-prop="row-rule-inset" data-unit="px" oninput="mcRowRuleOVal.value=this.value"/>
         <label>Row-rule-style:</label>
         <select data-prop="row-rule-style">
+          <option value="none">none</option>
+          <option value="hidden">hidden</option>
           <option value="solid">solid</option>
-          <option value="dashed">dashed</option>
+          <option value="dashed" selected>dashed</option>
           <option value="dotted">dotted</option>
-        </select>
-        <label>Row-rule-color:</label>
-        <input type="color" class="color-picker" data-prop="row-rule-color" value="#888888" />
-        <label>Row-rule-style:</label>
-        <select data-prop="row-rule-style">
-          <option value="solid">solid</option>
-          <option value="dashed">dashed</option>
-          <option value="dotted">dotted</option>
+          <option value="double">double</option>
+          <option value="groove">groove</option>
+          <option value="ridge">ridge</option>
+          <option value="inset">inset</option>
+          <option value="outset">outset</option>
         </select>
         <label>Row-rule-color:</label>
         <input type="color" class="color-picker" data-prop="row-rule-color" value="#888888" />
         <label>Row-rule-break:</label>
         <select data-prop="row-rule-break">
+          <option value="normal">normal</option>
           <option value="none">none</option>
           <option value="intersection">intersection</option>
-          <option value="spanning-item">spanning-item</option>
         </select>
         <label>Rule-overlap:</label>
         <select data-prop="rule-overlap">
@@ -462,11 +418,9 @@
       </aside>
       <div class="preview multicol">
         <h3>Exploring Gap Decorations</h3>
-        <p>Gap decorations provide a flexible way to visually separate content without extra markup. Columns adapt
-          dynamically to viewport size, maintaining readability.</p>
-        <p>Use <strong>column-rule</strong> properties to style separators, control their inset, and define how they
-          interact with multi-column spans.</p>
-        <blockquote>“Effective gap decorations enhance layout clarity while preserving semantic structure.”</blockquote>
+        <p>Gap decorations provide a flexible way to visually separate content without extra markup. Columns adapt dynamically to viewport size, maintaining readability.</p>
+        <p>Use <strong>column-rule</strong> properties to style separators, control their inset, and define how they interact with multi-column spans.</p>
+        <blockquote>"Effective gap decorations enhance layout clarity while preserving semantic structure."</blockquote>
         <ul>
           <li>Adjust <em>column-gap</em> for spacing.</li>
           <li>Tweak <em>column-rule-width</em> and <em>column-rule-inset</em>.</li>
@@ -474,31 +428,29 @@
         </ul>
         <p>Combine with <code>rule-overlap</code> to layer rules in complex layouts.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec est at dolor scelerisque elementum.</p>
-        <p>Mauris posuere, libero non suscipit consectetur, odio tortor vulputate mi, vitae consequat justo arcu non ex.
-        </p>
-        <p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Integer a pulvinar
-          erat.</p>
+        <p>Mauris posuere, libero non suscipit consectetur, odio tortor vulputate mi, vitae consequat justo arcu non ex.</p>
+        <p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Integer a pulvinar erat.</p>
         <p>Fusce vehicula eros a lectus tincidunt, sit amet venenatis lorem ultrices.</p>
       </div>
     </div>
   </section>
 
 
-  <footer>Demo of CSS Gap Decorations Module Level 1 • Built by Your Name</footer>
+  <footer>CSS Gap Decorations Module Level 1</footer>
 
-  <script>
+<script>
 
-    // helper to convert “rgb(r, g, b)” → “#rrggbb”
-    function rgbToHex(rgb) {
-      const [r, g, b] = rgb.match(/\d+/g).map(n => parseInt(n));
-      return '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
-    }
+  // helper to convert "rgb(r, g, b)" → "#rrggbb"
+  function rgbToHex(rgb) {
+    const [r, g, b] = rgb.match(/\d+/g).map(n => parseInt(n));
+    return '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
+  }
 
-    document.querySelectorAll('.controls').forEach(panel => {
-      const preview = panel.closest('.demo-group').querySelector('.preview');
+  document.querySelectorAll('.controls').forEach(panel => {
+    const preview = panel.closest('.demo-group').querySelector('.preview');
 
 
-      // Initialize each control to match computed style
+    // Initialize each control to match computed style
       panel.querySelectorAll('input[data-prop], select[data-prop]').forEach(control => {
         const prop = control.dataset.prop;
         let computed = getComputedStyle(preview).getPropertyValue(prop).trim();
@@ -523,10 +475,9 @@
           const prop = input.dataset.prop;
           const unit = input.dataset.unit || '';
           preview.style.setProperty(prop, input.value + unit);
-        });
       });
     });
-  </script>
+  });
+</script>
 </body>
-
 </html>

--- a/css-gap-decorations/settings-list.html
+++ b/css-gap-decorations/settings-list.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Settings List - CSS Gap Decorations Demo</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg-page: #1a1a2e;
+    --bg-card: #16213e;
+    --text-primary: #eaf0fb;
+    --text-secondary: #7b8dad;
+    --text-muted: #4a5a78;
+    --accent: #e2b04a;
+    --rule-color: #243352;
+    --chevron-color: #4a5a78;
+    --code-bg: #243352;
+    --code-text: #c0c8dc;
+  }
+
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  body {
+    font-family: "Plus Jakarta Sans", sans-serif;
+    background: var(--bg-page);
+    padding: 40px 16px;
+    color: var(--text-primary);
+    min-height: 100vh;
+  }
+
+  .caption {
+    max-width: 400px;
+    margin: 0 auto 16px;
+    padding: 0 8px;
+  }
+
+  pre.caption {
+    background: var(--code-bg);
+    border-radius: 8px;
+    padding: 12px 16px;
+    overflow-x: auto;
+  }
+
+  pre.caption code {
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--code-text);
+    background: none;
+    padding: 0;
+    border-radius: 0;
+  }
+
+  .section-header {
+    max-width: 400px;
+    margin: 0 auto 8px;
+    padding: 0 8px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+  }
+
+  .settings-panel {
+    max-width: 400px;
+    margin: 0 auto;
+    background: var(--bg-card);
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: 0 2px 16px rgba(0, 0, 0, 0.25);
+
+    display: flex;
+    flex-direction: column;
+    row-gap: 1px;
+
+    row-rule: 1px solid var(--rule-color);
+    row-rule-width: repeat(2, 1px), 4px;
+    rule-inset-start: 16px;
+  }
+
+  .settings-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px;
+    font-size: 15px;
+    font-weight: 500;
+  }
+
+  .settings-item .label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .settings-item .icon {
+    font-size: 18px;
+    width: 24px;
+    text-align: center;
+    flex-shrink: 0;
+  }
+
+  .settings-item .value {
+    color: var(--text-secondary);
+    font-size: 14px;
+    font-weight: 400;
+  }
+
+  .settings-item .chevron {
+    color: var(--chevron-color);
+    font-size: 12px;
+    margin-left: 6px;
+  }
+
+  .settings-item .right {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+</style>
+</head>
+<body>
+
+<pre class="caption"><code>.flex-settings {
+  row-gap: 1px;
+  row-rule: 1px solid #243352;
+  row-rule-width: repeat(2, 1px), 4px;
+  rule-inset-start: 16px;
+}</code></pre>
+
+<p class="section-header">General</p>
+
+<div class="settings-panel">
+  <!-- Connectivity group -->
+  <div class="settings-item">
+    <span class="label">
+      <span class="icon">&#x1F4F6;</span>
+      <span>Wi-Fi</span>
+    </span>
+    <span class="right">
+      <span class="value">Home</span>
+      <span class="chevron">&#x276F;</span>
+    </span>
+  </div>
+  <div class="settings-item">
+    <span class="label">
+      <span class="icon">&#x1F91D;</span>
+      <span>Bluetooth</span>
+    </span>
+    <span class="right">
+      <span class="value">On</span>
+      <span class="chevron">&#x276F;</span>
+    </span>
+  </div>
+  <div class="settings-item">
+    <span class="label">
+      <span class="icon">&#x1F4F1;</span>
+      <span>Hotspot</span>
+    </span>
+    <span class="right">
+      <span class="value">Off</span>
+      <span class="chevron">&#x276F;</span>
+    </span>
+  </div>
+  <!-- Alerts group -->
+  <div class="settings-item">
+    <span class="label">
+      <span class="icon">&#x1F514;</span>
+      <span>Notifications</span>
+    </span>
+    <span class="right">
+      <span class="chevron">&#x276F;</span>
+    </span>
+  </div>
+  <div class="settings-item">
+    <span class="label">
+      <span class="icon">&#x1F50A;</span>
+      <span>Sound</span>
+    </span>
+    <span class="right">
+      <span class="chevron">&#x276F;</span>
+    </span>
+  </div>
+  <div class="settings-item">
+    <span class="label">
+      <span class="icon">&#x1F4F3;</span>
+      <span>Vibration</span>
+    </span>
+    <span class="right">
+      <span class="value">On</span>
+      <span class="chevron">&#x276F;</span>
+    </span>
+  </div>
+  <!-- System group -->
+  <div class="settings-item">
+    <span class="label">
+      <span class="icon">&#x2600;</span>
+      <span>Display</span>
+    </span>
+    <span class="right">
+      <span class="chevron">&#x276F;</span>
+    </span>
+  </div>
+  <div class="settings-item">
+    <span class="label">
+      <span class="icon">&#x1F4BE;</span>
+      <span>Storage</span>
+    </span>
+    <span class="right">
+      <span class="value">28 GB</span>
+      <span class="chevron">&#x276F;</span>
+    </span>
+  </div>
+  <div class="settings-item">
+    <span class="label">
+      <span class="icon">&#x1F50B;</span>
+      <span>Battery</span>
+    </span>
+    <span class="right">
+      <span class="value">84%</span>
+      <span class="chevron">&#x276F;</span>
+    </span>
+  </div>
+</div>
+
+</body>
+</html>

--- a/css-gap-decorations/split-screen.html
+++ b/css-gap-decorations/split-screen.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Gap Decorations: Split Screen</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg-page: #f4f1ec;
+      --bg-sidebar: #1e1e2e;
+      --bg-editor: #faf9f7;
+      --bg-preview: #ffffff;
+      --text-primary: #2c2c34;
+      --text-muted: #6e6b7b;
+      --text-sidebar: #cdd6f4;
+      --text-sidebar-muted: #7f849c;
+      --accent: #cba6f7;
+      --accent-dim: #45475a;
+      --rule-color: #d4d0c8;
+      --font-body: 'DM Sans', sans-serif;
+      --font-mono: 'IBM Plex Mono', monospace;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: var(--font-body);
+      background: var(--bg-page);
+      background-image: url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence baseFrequency='0.9' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+      color: var(--text-primary);
+      padding: 40px 24px;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    .caption {
+      max-width: 880px;
+      margin: 0 auto 32px;
+      font-size: 14px;
+      color: var(--text-muted);
+    }
+
+    .caption h1 {
+      font-size: 22px;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin-bottom: 6px;
+      letter-spacing: -0.02em;
+    }
+
+    .caption p {
+      max-width: 560px;
+    }
+
+    .caption pre {
+      background: rgba(0, 0, 0, 0.05);
+      border-radius: 6px;
+      padding: 12px 16px;
+      overflow-x: auto;
+      max-width: 560px;
+    }
+
+    .caption pre code {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      line-height: 1.6;
+      background: none;
+      padding: 0;
+      border-radius: 0;
+    }
+
+    .caption code {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      background: rgba(0, 0, 0, 0.06);
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+
+    .split {
+      display: flex;
+      flex-direction: row;
+      gap: 1px;
+      column-rule-width: 2px;
+      column-rule-style: dashed, solid;
+      column-rule-color: var(--rule-color);
+      row-rule-width: 2px;
+      row-rule-style: dashed, solid;
+      row-rule-color: var(--rule-color);
+      border-radius: 12px;
+      overflow: hidden;
+      max-width: 880px;
+      margin: 0 auto;
+      box-shadow:
+        0 1px 3px rgba(0, 0, 0, 0.06),
+        0 8px 24px rgba(0, 0, 0, 0.08);
+    }
+
+    /* Sidebar panel */
+    .panel-sidebar {
+      flex: 0 0 200px;
+      background: var(--bg-editor);
+      padding: 24px 20px;
+      min-width: 0;
+    }
+
+    .panel-sidebar h2 {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      margin-bottom: 16px;
+    }
+
+    .nav-list {
+      list-style: none;
+      font-size: 13px;
+      color: var(--text-primary);
+    }
+
+    .nav-list li {
+      padding: 5px 10px;
+      border-radius: 6px;
+      cursor: default;
+    }
+
+    .nav-list li.active {
+      background: rgba(0, 0, 0, 0.06);
+      font-weight: 500;
+    }
+
+    .nav-list li::before {
+      content: '';
+      display: inline-block;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      margin-right: 10px;
+      background: var(--text-muted);
+      vertical-align: middle;
+    }
+
+    .nav-list li.active::before {
+      background: var(--text-primary);
+    }
+
+    /* Main content panel */
+    .panel-main {
+      flex: 1;
+      background: var(--bg-editor);
+      padding: 24px;
+      min-width: 0;
+    }
+
+    .panel-main h2 {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      margin-bottom: 16px;
+    }
+
+    .content-block {
+      font-size: 14px;
+      line-height: 1.7;
+      color: var(--text-primary);
+    }
+
+    .content-block p {
+      margin-bottom: 12px;
+    }
+
+    .content-swatch {
+      display: inline-block;
+      width: 100%;
+      height: 10px;
+      background: #ddd8d0;
+      border-radius: 4px;
+      margin-bottom: 10px;
+    }
+
+    .content-swatch:nth-child(2) { width: 92%; }
+    .content-swatch:nth-child(3) { width: 78%; }
+    .content-swatch:nth-child(4) { width: 85%; }
+    .content-swatch:nth-child(5) { width: 65%; }
+    .content-swatch:nth-child(6) { width: 90%; }
+
+    /* Detail panel */
+    .panel-detail {
+      flex: 1;
+      background: var(--bg-preview);
+      padding: 24px;
+      min-width: 0;
+    }
+
+    .panel-detail h2 {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      margin-bottom: 16px;
+    }
+
+    .detail-card {
+      width: 100%;
+      height: 48px;
+      background: linear-gradient(135deg, #cba6f7 0%, #89b4fa 100%);
+      border-radius: 8px;
+      margin-bottom: 16px;
+    }
+
+    .detail-line {
+      height: 10px;
+      background: #e8e6e1;
+      border-radius: 4px;
+      margin-bottom: 10px;
+    }
+
+    .detail-line:nth-child(2) { width: 85%; }
+    .detail-line:nth-child(3) { width: 70%; }
+    .detail-line:nth-child(4) { width: 90%; }
+    .detail-line:nth-child(5) { width: 55%; }
+
+    @media (max-width: 600px), (orientation: portrait) {
+      .split {
+        flex-direction: column;
+      }
+
+      .panel-sidebar {
+        flex: none;
+      }
+
+      .nav-list {
+        display: flex;
+        gap: 4px;
+        flex-wrap: wrap;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="caption">
+    <h1>Split Screen with Gap Decorations</h1>
+    <pre><code>.flex-split {
+  gap: 1px;
+  column-rule-width: 2px;
+  column-rule-style: dashed, solid;
+  column-rule-color: #d4d0c8;
+  row-rule-width: 2px;
+  row-rule-style: dashed, solid;
+  row-rule-color: #d4d0c8;
+}
+@media (max-width: 600px) {
+  .flex-split { flex-direction: column; }
+}</code></pre>
+  </div>
+
+  <div class="split">
+    <div class="panel-sidebar">
+      <h2>Menu</h2>
+      <ul class="nav-list">
+        <li class="active">Dashboard</li>
+        <li>Analytics</li>
+        <li>Reports</li>
+        <li>Settings</li>
+      </ul>
+    </div>
+    <div class="panel-main">
+      <h2>Content</h2>
+      <div class="content-block">
+        <div class="content-swatch"></div>
+        <div class="content-swatch"></div>
+        <div class="content-swatch"></div>
+        <div class="content-swatch"></div>
+        <div class="content-swatch"></div>
+        <div class="content-swatch"></div>
+      </div>
+    </div>
+    <div class="panel-detail">
+      <h2>Details</h2>
+      <div class="detail-card"></div>
+      <div class="detail-line"></div>
+      <div class="detail-line"></div>
+      <div class="detail-line"></div>
+      <div class="detail-line"></div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add 6 new CSS gap decorations demos from the blog series: article-grid, calendar-week, dashboard-grid, dynamic-items, settings-list, split-screen
- Replace outdated playground with current version reflecting the latest CSS Gaps spec
- Update README with links to all new demos

## Test plan
- [x] Open each demo in a Chromium browser and verify rendering
- [x] Verify playground controls update layout properties in real time
- [x] Confirm README links match actual filenames