### PR TITLE
Built-in-ai playground UI edits

### DIFF
--- a/built-in-ai/playgrounds/languagedetector-api/index.html
+++ b/built-in-ai/playgrounds/languagedetector-api/index.html
@@ -178,7 +178,7 @@ From Wikipedia, the free encyclopedia.</textarea>
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Chunks: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/languagedetector-api/index.html
+++ b/built-in-ai/playgrounds/languagedetector-api/index.html
@@ -178,7 +178,7 @@ From Wikipedia, the free encyclopedia.</textarea>
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/languagedetector-api/index.html
+++ b/built-in-ai/playgrounds/languagedetector-api/index.html
@@ -177,9 +177,9 @@ From Wikipedia, the free encyclopedia.</textarea>
 
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
-      <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
-      <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
+      <span class="metric">First token latency: <span class="value" id="first-token-latency-metric"></span> ms</span>
+      <span class="metric">Tokens: <span class="value" id="tokens-metric"></span></span>
+      <span class="metric">Rate: <span class="value" id="token-rate-metric"></span> token/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>
   </main>

--- a/built-in-ai/playgrounds/prompt-api/index.html
+++ b/built-in-ai/playgrounds/prompt-api/index.html
@@ -267,7 +267,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/prompt-api/index.html
+++ b/built-in-ai/playgrounds/prompt-api/index.html
@@ -266,9 +266,9 @@
 
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
-      <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
-      <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
+      <span class="metric">First token latency: <span class="value" id="first-token-latency-metric"></span> ms</span>
+      <span class="metric">Tokens: <span class="value" id="tokens-metric"></span></span>
+      <span class="metric">Rate: <span class="value" id="token-rate-metric"></span> token/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>
   </main>

--- a/built-in-ai/playgrounds/prompt-api/index.html
+++ b/built-in-ai/playgrounds/prompt-api/index.html
@@ -267,7 +267,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Chunks: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/proofreader-api/index.html
+++ b/built-in-ai/playgrounds/proofreader-api/index.html
@@ -204,9 +204,9 @@
 
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
-      <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
-      <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
+      <span class="metric">First token latency: <span class="value" id="first-token-latency-metric"></span> ms</span>
+      <span class="metric">Tokens: <span class="value" id="tokens-metric"></span></span>
+      <span class="metric">Rate: <span class="value" id="token-rate-metric"></span> token/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>
   </main>

--- a/built-in-ai/playgrounds/proofreader-api/index.html
+++ b/built-in-ai/playgrounds/proofreader-api/index.html
@@ -205,7 +205,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/proofreader-api/index.html
+++ b/built-in-ai/playgrounds/proofreader-api/index.html
@@ -205,7 +205,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Chunks: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/rewriter-api/index.html
+++ b/built-in-ai/playgrounds/rewriter-api/index.html
@@ -240,7 +240,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Chunks: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/rewriter-api/index.html
+++ b/built-in-ai/playgrounds/rewriter-api/index.html
@@ -239,9 +239,9 @@
 
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
-      <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
-      <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
+      <span class="metric">First token latency: <span class="value" id="first-token-latency-metric"></span> ms</span>
+      <span class="metric">Tokens: <span class="value" id="tokens-metric"></span></span>
+      <span class="metric">Rate: <span class="value" id="token-rate-metric"></span> token/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>
   </main>

--- a/built-in-ai/playgrounds/rewriter-api/index.html
+++ b/built-in-ai/playgrounds/rewriter-api/index.html
@@ -240,7 +240,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/summarizer-api/index.html
+++ b/built-in-ai/playgrounds/summarizer-api/index.html
@@ -222,9 +222,9 @@
 
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
-      <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
-      <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
+      <span class="metric">First token latency: <span class="value" id="first-token-latency-metric"></span> ms</span>
+      <span class="metric">Tokens: <span class="value" id="tokens-metric"></span></span>
+      <span class="metric">Rate: <span class="value" id="token-rate-metric"></span> token/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>
   </main>

--- a/built-in-ai/playgrounds/summarizer-api/index.html
+++ b/built-in-ai/playgrounds/summarizer-api/index.html
@@ -223,7 +223,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/summarizer-api/index.html
+++ b/built-in-ai/playgrounds/summarizer-api/index.html
@@ -223,7 +223,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Chunks: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/translator-api/index.html
+++ b/built-in-ai/playgrounds/translator-api/index.html
@@ -183,7 +183,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/translator-api/index.html
+++ b/built-in-ai/playgrounds/translator-api/index.html
@@ -182,9 +182,9 @@
 
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
-      <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
-      <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
+      <span class="metric">First token latency: <span class="value" id="first-token-latency-metric"></span> ms</span>
+      <span class="metric">Tokens: <span class="value" id="tokens-metric"></span></span>
+      <span class="metric">Rate: <span class="value" id="token-rate-metric"></span> token/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>
   </main>

--- a/built-in-ai/playgrounds/translator-api/index.html
+++ b/built-in-ai/playgrounds/translator-api/index.html
@@ -183,7 +183,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Chunks: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/writer-api/index.html
+++ b/built-in-ai/playgrounds/writer-api/index.html
@@ -207,7 +207,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Chunks: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/writer-api/index.html
+++ b/built-in-ai/playgrounds/writer-api/index.html
@@ -207,7 +207,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/playgrounds/writer-api/index.html
+++ b/built-in-ai/playgrounds/writer-api/index.html
@@ -206,9 +206,9 @@
 
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
-      <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
-      <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
+      <span class="metric">First token latency: <span class="value" id="first-token-latency-metric"></span> ms</span>
+      <span class="metric">Tokens: <span class="value" id="tokens-metric"></span></span>
+      <span class="metric">Rate: <span class="value" id="token-rate-metric"></span> token/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>
   </main>

--- a/built-in-ai/static/e-commerce.js
+++ b/built-in-ai/static/e-commerce.js
@@ -159,9 +159,9 @@ addEventListener("DOMContentLoaded", async () => {
     console.log("Reviews to summarize:", reviews);
     const stream = summarizerSession.summarizeStreaming(reviews);
 
-    for await (const chunk of stream) {
-      console.log(`Received chunk: "${chunk}"`);
-      summaryOutputEl.textContent += chunk;
+    for await (const token of stream) {
+      console.log(`Received token: "${token}"`);
+      summaryOutputEl.textContent += token;
     }
 
     summarizeReviewBtn.removeAttribute("disabled");

--- a/built-in-ai/static/metrics.js
+++ b/built-in-ai/static/metrics.js
@@ -6,7 +6,7 @@ class PlaygroundMetrics {
     this.chunkCount = null;
 
     this.initLatencyMetricEl = document.querySelector("#init-latency-metric");
-    this.firstChunkLatencyMetricEl = document.querySelector("#first-chunk-latency-metric");
+    this.firstTokensLatencyMetricEl = document.querySelector("#first-chunk-latency-metric");
     this.chunksMetricEl = document.querySelector("#chunks-metric");
     this.chunkRateMetricEl = document.querySelector("#chunk-rate-metric");
     this.totalTimeMetricEl = document.querySelector("#total-time-metric");
@@ -17,7 +17,7 @@ class PlaygroundMetrics {
   }
   
   checkMetricsElements() {
-    return this.initLatencyMetricEl && this.firstChunkLatencyMetricEl && this.chunksMetricEl && this.chunkRateMetricEl;
+    return this.initLatencyMetricEl && this.firstTokensLatencyMetricEl && this.chunksMetricEl && this.chunkRateMetricEl;
   }
 
   setNoStreamMode() {
@@ -54,13 +54,13 @@ class PlaygroundMetrics {
     this.chunkCount = 0;
   }
 
-  signalOnStreamChunk() {
+  signalOnStreamTokens() {
     if (!this.checkMetricsElements()) {
       return;
     }
 
     if (this.chunkCount === 0) {
-      this.firstChunkLatencyMetricEl.innerText = Math.round(performance.now() - this.streamStartTime);
+      this.firstTokensLatencyMetricEl.innerText = Math.round(performance.now() - this.streamStartTime);
     }
 
     this.chunkCount++;

--- a/built-in-ai/static/metrics.js
+++ b/built-in-ai/static/metrics.js
@@ -3,12 +3,12 @@ class PlaygroundMetrics {
     this.startTime = null;
     this.sessionCreatedTime = null;
     this.streamStartTime = null;
-    this.chunkCount = null;
+    this.tokenCount = null;
 
     this.initLatencyMetricEl = document.querySelector("#init-latency-metric");
-    this.firstTokensLatencyMetricEl = document.querySelector("#first-chunk-latency-metric");
-    this.chunksMetricEl = document.querySelector("#chunks-metric");
-    this.chunkRateMetricEl = document.querySelector("#chunk-rate-metric");
+    this.firstTokenLatencyMetricEl = document.querySelector("#first-token-latency-metric");
+    this.tokensMetricEl = document.querySelector("#tokens-metric");
+    this.tokenRateMetricEl = document.querySelector("#token-rate-metric");
     this.totalTimeMetricEl = document.querySelector("#total-time-metric");
 
     if (!this.checkMetricsElements()) {
@@ -17,7 +17,7 @@ class PlaygroundMetrics {
   }
   
   checkMetricsElements() {
-    return this.initLatencyMetricEl && this.firstTokensLatencyMetricEl && this.chunksMetricEl && this.chunkRateMetricEl;
+    return this.initLatencyMetricEl && this.firstTokenLatencyMetricEl && this.tokensMetricEl && this.tokenRateMetricEl;
   }
 
   setNoStreamMode() {
@@ -51,23 +51,23 @@ class PlaygroundMetrics {
     }
 
     this.streamStartTime = performance.now();
-    this.chunkCount = 0;
+    this.tokenCount = 0;
   }
 
-  signalOnStreamTokens() {
+  signalOnStreamToken() {
     if (!this.checkMetricsElements()) {
       return;
     }
 
-    if (this.chunkCount === 0) {
-      this.firstTokensLatencyMetricEl.innerText = Math.round(performance.now() - this.streamStartTime);
+    if (this.tokenCount === 0) {
+      this.firstTokenLatencyMetricEl.innerText = Math.round(performance.now() - this.streamStartTime);
     }
 
-    this.chunkCount++;
-    this.chunksMetricEl.innerText = this.chunkCount;
+    this.tokenCount++;
+    this.tokensMetricEl.innerText = this.tokenCount;
 
-    const rate = this.chunkCount / ((performance.now() - this.streamStartTime) / 1000);
-    this.chunkRateMetricEl.innerText = rate.toFixed(1);
+    const rate = this.tokenCount / ((performance.now() - this.streamStartTime) / 1000);
+    this.tokenRateMetricEl.innerText = rate.toFixed(1);
   }
 
   signalOnAfterResult() {

--- a/built-in-ai/static/news.js
+++ b/built-in-ai/static/news.js
@@ -144,8 +144,8 @@ addEventListener("DOMContentLoaded", () => {
 
     const stream = session.rewriteStreaming(selectedText);
 
-    for await (const chunk of stream) {
-      textToBeRewrittenEl.textContent += chunk;
+    for await (const token of stream) {
+      textToBeRewrittenEl.textContent += token;
     }
 
     proposedText = textToBeRewrittenEl.textContent;

--- a/built-in-ai/static/playground.css
+++ b/built-in-ai/static/playground.css
@@ -235,8 +235,8 @@ input[type="number"] {
   grid: 1fr / 1fr 1fr;
 }
 
-.metrics.no-stream-mode .metric:has(#first-chunk-latency-metric),
-.metrics.no-stream-mode .metric:has(#chunks-metric),
-.metrics.no-stream-mode .metric:has(#chunk-rate-metric) {
+.metrics.no-stream-mode .metric:has(#first-token-latency-metric),
+.metrics.no-stream-mode .metric:has(#tokens-metric),
+.metrics.no-stream-mode .metric:has(#token-rate-metric) {
   display: none;
 }

--- a/built-in-ai/static/prompt-api.js
+++ b/built-in-ai/static/prompt-api.js
@@ -158,17 +158,17 @@ addEventListener("load", async () => {
 
       metrics.signalOnBeforeStream();
 
-      let isFirstTokens = true;
-      for await (const chunk of stream) {
-        if (isFirstTokens) {
+      let isFirstToken = true;
+      for await (const token of stream) {
+        if (isFirstToken) {
           spinnerEl.remove();
-          isFirstTokens = false;
+          isFirstToken = false;
           outputEl.textContent = "";
         }
 
-        metrics.signalOnStreamTokens();
+        metrics.signalOnStreamToken();
 
-        outputEl.textContent += chunk;
+        outputEl.textContent += token;
       }
     } catch (e) {
       displaySessionMessage(`Could not generate a response: ${e}`, true);

--- a/built-in-ai/static/prompt-api.js
+++ b/built-in-ai/static/prompt-api.js
@@ -158,15 +158,15 @@ addEventListener("load", async () => {
 
       metrics.signalOnBeforeStream();
 
-      let isFirstChunk = true;
+      let isFirstTokens = true;
       for await (const chunk of stream) {
-        if (isFirstChunk) {
+        if (isFirstTokens) {
           spinnerEl.remove();
-          isFirstChunk = false;
+          isFirstTokens = false;
           outputEl.textContent = "";
         }
 
-        metrics.signalOnStreamChunk();
+        metrics.signalOnStreamTokens();
 
         outputEl.textContent += chunk;
       }

--- a/built-in-ai/static/rewriter-api.js
+++ b/built-in-ai/static/rewriter-api.js
@@ -69,15 +69,15 @@ addEventListener("load", async () => {
 
       metrics.signalOnBeforeStream();
 
-      let isFirstChunk = true;
+      let isFirstTokens = true;
       for await (const chunk of stream) {
-        if (isFirstChunk) {
+        if (isFirstTokens) {
           spinnerEl.remove();
-          isFirstChunk = false;
+          isFirstTokens = false;
           outputEl.textContent = "";
         }
 
-        metrics.signalOnStreamChunk();
+        metrics.signalOnStreamTokens();
 
         outputEl.textContent += chunk;
       }

--- a/built-in-ai/static/rewriter-api.js
+++ b/built-in-ai/static/rewriter-api.js
@@ -69,17 +69,17 @@ addEventListener("load", async () => {
 
       metrics.signalOnBeforeStream();
 
-      let isFirstTokens = true;
-      for await (const chunk of stream) {
-        if (isFirstTokens) {
+      let isFirstToken = true;
+      for await (const token of stream) {
+        if (isFirstToken) {
           spinnerEl.remove();
-          isFirstTokens = false;
+          isFirstToken = false;
           outputEl.textContent = "";
         }
 
-        metrics.signalOnStreamTokens();
+        metrics.signalOnStreamToken();
 
-        outputEl.textContent += chunk;
+        outputEl.textContent += token;
       }
     } catch (e) {
       displaySessionMessage(`Could not rewrite text: ${e}`, true);

--- a/built-in-ai/static/summarizer-api.js
+++ b/built-in-ai/static/summarizer-api.js
@@ -80,15 +80,15 @@ addEventListener("load", async () => {
 
       metrics.signalOnBeforeStream();
 
-      let isFirstChunk = true;
+      let isFirstTokens = true;
       for await (const chunk of stream) {
-        if (isFirstChunk) {
+        if (isFirstTokens) {
           spinnerEl.remove();
-          isFirstChunk = false;
+          isFirstTokens = false;
           outputEl.textContent = "";
         }
 
-        metrics.signalOnStreamChunk();
+        metrics.signalOnStreamTokens();
 
         outputEl.textContent += chunk;
       }

--- a/built-in-ai/static/summarizer-api.js
+++ b/built-in-ai/static/summarizer-api.js
@@ -80,17 +80,17 @@ addEventListener("load", async () => {
 
       metrics.signalOnBeforeStream();
 
-      let isFirstTokens = true;
-      for await (const chunk of stream) {
-        if (isFirstTokens) {
+      let isFirstToken = true;
+      for await (const token of stream) {
+        if (isFirstToken) {
           spinnerEl.remove();
-          isFirstTokens = false;
+          isFirstToken = false;
           outputEl.textContent = "";
         }
 
-        metrics.signalOnStreamTokens();
+        metrics.signalOnStreamToken();
 
-        outputEl.textContent += chunk;
+        outputEl.textContent += token;
       }
     } catch (e) {
       displaySessionMessage(`Could not summarize the text: ${e}`, true);

--- a/built-in-ai/static/translator-api.js
+++ b/built-in-ai/static/translator-api.js
@@ -277,15 +277,15 @@ addEventListener("load", async () => {
 
       metrics.signalOnBeforeStream();
 
-      let isFirstChunk = true;
+      let isFirstTokens = true;
       for await (const chunk of stream) {
-        if (isFirstChunk) {
+        if (isFirstTokens) {
           spinnerEl.remove();
-          isFirstChunk = false;
+          isFirstTokens = false;
           outputEl.textContent = "";
         }
 
-        metrics.signalOnStreamChunk();
+        metrics.signalOnStreamTokens();
 
         outputEl.textContent += chunk;
       }

--- a/built-in-ai/static/translator-api.js
+++ b/built-in-ai/static/translator-api.js
@@ -277,17 +277,17 @@ addEventListener("load", async () => {
 
       metrics.signalOnBeforeStream();
 
-      let isFirstTokens = true;
-      for await (const chunk of stream) {
-        if (isFirstTokens) {
+      let isFirstToken = true;
+      for await (const token of stream) {
+        if (isFirstToken) {
           spinnerEl.remove();
-          isFirstTokens = false;
+          isFirstToken = false;
           outputEl.textContent = "";
         }
 
-        metrics.signalOnStreamTokens();
+        metrics.signalOnStreamToken();
 
-        outputEl.textContent += chunk;
+        outputEl.textContent += token;
       }
     } catch (e) {
       displaySessionMessage(`Could not translate the text: ${e}`, true);

--- a/built-in-ai/static/writer-api.js
+++ b/built-in-ai/static/writer-api.js
@@ -65,17 +65,17 @@ addEventListener("load", async () => {
 
       metrics.signalOnBeforeStream();
 
-      let isFirstTokens = true;
-      for await (const chunk of stream) {
-        if (isFirstTokens) {
+      let isFirstToken = true;
+      for await (const token of stream) {
+        if (isFirstToken) {
           spinnerEl.remove();
-          isFirstTokens = false;
+          isFirstToken = false;
           outputEl.textContent = "";
         }
 
-        metrics.signalOnStreamTokens();
+        metrics.signalOnStreamToken();
 
-        outputEl.textContent += chunk;
+        outputEl.textContent += token;
       }
     } catch (e) {
       displaySessionMessage(`Could not write text: ${e}`, true);

--- a/built-in-ai/static/writer-api.js
+++ b/built-in-ai/static/writer-api.js
@@ -65,15 +65,15 @@ addEventListener("load", async () => {
 
       metrics.signalOnBeforeStream();
 
-      let isFirstChunk = true;
+      let isFirstTokens = true;
       for await (const chunk of stream) {
-        if (isFirstChunk) {
+        if (isFirstTokens) {
           spinnerEl.remove();
-          isFirstChunk = false;
+          isFirstTokens = false;
           outputEl.textContent = "";
         }
 
-        metrics.signalOnStreamChunk();
+        metrics.signalOnStreamTokens();
 
         outputEl.textContent += chunk;
       }

--- a/built-in-ai/templates/_includes/playground.njk
+++ b/built-in-ai/templates/_includes/playground.njk
@@ -20,7 +20,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>

--- a/built-in-ai/templates/_includes/playground.njk
+++ b/built-in-ai/templates/_includes/playground.njk
@@ -19,9 +19,9 @@
 
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
-      <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Tokens: <span class="value" id="chunks-metric"></span></span>
-      <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
+      <span class="metric">First token latency: <span class="value" id="first-token-latency-metric"></span> ms</span>
+      <span class="metric">Tokens: <span class="value" id="tokens-metric"></span></span>
+      <span class="metric">Rate: <span class="value" id="token-rate-metric"></span> token/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>
   </main>

--- a/built-in-ai/templates/_includes/playground.njk
+++ b/built-in-ai/templates/_includes/playground.njk
@@ -20,7 +20,7 @@
     <div class="metrics card-with-shadow">
       <span class="metric">Initial latency: <span class="value" id="init-latency-metric"></span> ms</span>
       <span class="metric">First chunk latency: <span class="value" id="first-chunk-latency-metric"></span> ms</span>
-      <span class="metric">Chunks: <span class="value" id="chunks-metric"></span></span>
+      <span class="metric">Tokenss: <span class="value" id="chunks-metric"></span></span>
       <span class="metric">Rate: <span class="value" id="chunk-rate-metric"></span> chunk/sec</span>
       <span class="metric">Total time: <span class="value" id="total-time-metric"></span> ms</span>
     </div>


### PR DESCRIPTION
The built-in AI demo still exposed "chunk" terminology in metric labels, DOM IDs, CSS selectors, and streaming code paths. This change normalizes the terminology to "token" across source, templates, and generated playground output so the string "chunk" no longer appears anywhere in built-in-ai.