### PR TITLE
Add upgraded personal-site gap-decorations demo

### DIFF
--- a/css-gap-decorations/README.md
+++ b/css-gap-decorations/README.md
@@ -12,6 +12,7 @@ This directory contains demos that showcase the use of [CSS Gap Decorations](htt
 * [Guitar Fretboard](https://microsoftedge.github.io/Demos/css-gap-decorations/guitar-fretboard.html) - `guitar-fretboard.html`
 * [Notebook](https://microsoftedge.github.io/Demos/css-gap-decorations/notebook.html) - `notebook.html`
 * [Personal site](https://microsoftedge.github.io/Demos/css-gap-decorations/personal-site.html) - `personal-site.html`
+* [Personal site (upgraded)](https://microsoftedge.github.io/Demos/css-gap-decorations/personal-site-upgraded.html) - `personal-site-upgraded.html`
 * [The Daily Oddity](https://microsoftedge.github.io/Demos/css-gap-decorations/the-daily-oddity.html) - `the-daily-oddity.html`
 * [Article Grid](https://microsoftedge.github.io/Demos/css-gap-decorations/article-grid.html) - `article-grid.html`
 * [Calendar Week View](https://microsoftedge.github.io/Demos/css-gap-decorations/calendar-week.html) - `calendar-week.html`

--- a/css-gap-decorations/personal-site-upgraded.html
+++ b/css-gap-decorations/personal-site-upgraded.html
@@ -60,20 +60,14 @@
     }
 
     /* ---- Base content styling --------------------------------------- */
-    /* Like Patrick's starter (which set `article img { width: 100%;
-       max-width: 600px; height: 100%; object-fit: cover }`), we size the
-       masthead photos up front. This is ordinary image hygiene, not a gap
-       decoration: an unstyled <img> reports its natural width as the flex
-       item's min-content size, which would stop flex-basis from shrinking
-       it and blow the layout apart. With this in place, the photos behave
-       like any other block and the gap-decoration steps stay clean. */
-    .portrait {
-      max-width: 280px;
-    }
-
-    .portrait img {
+    /* Size the masthead photos to a square crop up front. An unstyled <img>
+       reports its natural width as the flex item's min-content size, which
+       would stop flex-basis from shrinking it; a fixed aspect ratio plus
+       object-fit keeps every photo the same shape and lets the
+       gap-decoration steps stay clean. */
+    .photo img {
       width: 100%;
-      height: 100%;
+      aspect-ratio: 1 / 1;
       object-fit: cover;
     }
 
@@ -92,8 +86,8 @@
 
     /* ---- Home: masthead with varied flex-basis over two lines ------- */
     /* Echoing the original demo's main grid, the masthead blocks declare
-       DIFFERENT flex-basis values — wide text blocks (420px / 360px) next
-       to narrow image and aside blocks (200px) — so the row wraps into
+       DIFFERENT flex-basis values — wide text blocks (26.25rem / 22.5rem) next
+       to narrow image and aside blocks (12.5rem) — so the row wraps into
        two lines. That makes both decorations earn their place: row-rule
        draws between the two lines and column-rule between the items in a
        line. column-rule-inset: 0 keeps the vertical rules spanning each
@@ -110,15 +104,21 @@
     }
 
     .home > * {
-      flex: 1 1 200px;
+      flex: 1 1 12.5rem;
     }
 
     .home .greeting {
-      flex-basis: 420px;
+      flex-basis: 26.25rem;
     }
 
     .home .note {
-      flex-basis: 360px;
+      flex-basis: 22.5rem;
+    }
+
+    /* Keep the masthead photos narrow and uniform: let the text blocks absorb
+       the leftover space so a photo never balloons to fill its row. */
+    .home .photo {
+      flex-grow: 0;
     }
 
     .home .greeting .lead {
@@ -219,18 +219,19 @@
     }
 
     /* ---- About: profile card (avatar | bio) ------------------------- */
-    /* A circular portrait on the left, heading and bio on the right,
-       divided by a single vertical hairline. column-rule-inset pulls the
-       rule in from the top and bottom so it reads as a clean gutter
-       rather than a full-height bar (echoing the home masthead). */
+    /* A circular photo on the left, heading and bio on the right, divided by a
+       single vertical hairline. align-items: center vertically centers the
+       avatar against the taller text column, and a generous column-rule-inset
+       trims the divider top and bottom so it reads as a short centered stroke
+       rather than a full-height bar. */
     .about .bio {
       display: flex;
       flex-wrap: wrap;
-      align-items: start;
+      align-items: center;
       gap: 2.5rem;
 
       column-rule: 2px solid #999;
-      column-rule-inset: 0.5rem;
+      column-rule-inset: 2.5rem;
     }
 
     .about .avatar {
@@ -242,7 +243,7 @@
     }
 
     .about .bio .text {
-      flex: 1 1 320px;
+      flex: 1 1 20rem;
     }
 
     .about .bio .text p {
@@ -253,18 +254,36 @@
       margin-bottom: 0;
     }
 
-    /* ---- Links: inline row with dashed separators ------------------- */
-    /* Plain dashed column rules, reminiscent of the nav at the top. */
+    /* ---- Links: a grid that plays with colour, overlap, and insets --- */
+    /* A roomy grid of links gives the gap decorations space to show off three
+       of the newer controls at once:
+         - different colours per direction (gold rows, alternating blue/magenta
+           columns) so the rules read as a pattern, not a uniform mesh;
+         - rule-overlap, which decides who wins where they cross — here the gold
+           rows paint over the columns;
+         - rule-inset-cap vs rule-inset-junction, trimming the outer ends in
+           from the edges while letting the lines cross fully at the junctions. */
     .links ul {
       list-style: none;
       margin: 0;
       padding: 0;
 
-      display: flex;
-      flex-wrap: wrap;
-      gap: 2rem;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 2.5rem;
 
-      column-rule: 2px dashed #666;
+      row-rule: 4px solid #f5b700;
+      column-rule: 4px solid;
+      column-rule-color: repeat(auto, #4895ef, #f72585);
+
+      rule-overlap: row-over-column;
+
+      rule-inset-cap: 1rem;
+      rule-inset-junction: 0;
+    }
+
+    .links li {
+      padding: 0.4rem 0.2rem;
     }
 
     footer {
@@ -295,7 +314,7 @@
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
         ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
     </div>
-    <div class="portrait">
+    <div class="photo">
       <img src="cat.jpg" alt="A sleeping cat.">
     </div>
     <aside class="now">
@@ -312,7 +331,7 @@
         Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
         laborum.</p>
     </div>
-    <div class="portrait">
+    <div class="photo">
       <img src="tree.jpg" alt="An old olive tree trunk.">
     </div>
   </section>
@@ -385,6 +404,14 @@
       <li><a href="#">Mastodon</a></li>
       <li><a href="#">RSS</a></li>
       <li><a href="#">Email</a></li>
+      <li><a href="#">Bluesky</a></li>
+      <li><a href="#">LinkedIn</a></li>
+      <li><a href="#">YouTube</a></li>
+      <li><a href="#">Twitch</a></li>
+      <li><a href="#">Dribbble</a></li>
+      <li><a href="#">CodePen</a></li>
+      <li><a href="#">Discord</a></li>
+      <li><a href="#">Newsletter</a></li>
     </ul>
   </section>
 

--- a/css-gap-decorations/personal-site-upgraded.html
+++ b/css-gap-decorations/personal-site-upgraded.html
@@ -25,10 +25,6 @@
       margin: 0;
     }
 
-    /* The page itself is one grid. Each section is spaced apart, and the
-       off-white separators between them set the editorial rhythm.
-       repeat(auto, ...) keeps the rules working no matter how many
-       sections the site grows to. */
     body {
       display: grid;
       gap: 4rem;
@@ -59,12 +55,6 @@
       margin-bottom: 1.5rem;
     }
 
-    /* ---- Base content styling --------------------------------------- */
-    /* Size the masthead photos to a square crop up front. An unstyled <img>
-       reports its natural width as the flex item's min-content size, which
-       would stop flex-basis from shrinking it; a fixed aspect ratio plus
-       object-fit keeps every photo the same shape and lets the
-       gap-decoration steps stay clean. */
     .photo img {
       width: 100%;
       aspect-ratio: 1 / 1;
@@ -84,15 +74,6 @@
       column-rule: 2px dashed #666;
     }
 
-    /* ---- Home: masthead with varied flex-basis over two lines ------- */
-    /* Echoing the original demo's main grid, the masthead blocks declare
-       DIFFERENT flex-basis values — wide text blocks (26.25rem / 22.5rem) next
-       to narrow image and aside blocks (12.5rem) — so the row wraps into
-       two lines. That makes both decorations earn their place: row-rule
-       draws between the two lines and column-rule between the items in a
-       line. column-rule-inset: 0 keeps the vertical rules spanning each
-       line's content height rather than bleeding into the row gap.
-       (Photo sizing lives in the base content styles above.) */
     .home {
       display: flex;
       flex-wrap: wrap;
@@ -100,7 +81,7 @@
 
       row-rule: 2px solid #999;
       column-rule: 2px solid #999;
-      column-rule-inset: 0;
+      column-rule-inset: overlap-join;
     }
 
     .home > * {
@@ -115,8 +96,6 @@
       flex-basis: 22.5rem;
     }
 
-    /* Keep the masthead photos narrow and uniform: let the text blocks absorb
-       the leftover space so a photo never balloons to fill its row. */
     .home .photo {
       flex-grow: 0;
     }
@@ -153,23 +132,14 @@
     }
 
     /* ---- Blog: mixed-span grid of photo + title cards --------------- */
-    .blog .posts {
+    .posts {
       display: grid;
-      /* A fixed three-column grid keeps the spanning/empty-cell behaviour
-         below predictable. (On a real site you'd swap in
-         repeat(auto-fill, minmax(...)) for responsiveness; we pin it to 3
-         here so the demo always lays out the same way.) */
       grid-template-columns: repeat(3, 1fr);
       gap: 3rem;
 
       rule: 2px solid #999;
-
-
-      /* Only paint a separator when BOTH sides of the gap hold a post.
-         The interior hole left when a wide post bumps to the next row,
-         and the ragged last row, stay clean instead of dangling lines
-         into empty space. */
-      rule-visibility-items: between;
+      rule-visibility-items: around;
+      rule-inset: overlap-join;
     }
 
     .post {
@@ -218,13 +188,7 @@
       aspect-ratio: 3 / 4;
     }
 
-    /* ---- About: profile card (avatar | bio) ------------------------- */
-    /* A circular photo on the left, heading and bio on the right, divided by a
-       single vertical hairline. align-items: center vertically centers the
-       avatar against the taller text column, and a generous column-rule-inset
-       trims the divider top and bottom so it reads as a short centered stroke
-       rather than a full-height bar. */
-    .about .bio {
+    .bio {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
@@ -254,15 +218,6 @@
       margin-bottom: 0;
     }
 
-    /* ---- Links: a grid that plays with colour, overlap, and insets --- */
-    /* A roomy grid of links gives the gap decorations space to show off three
-       of the newer controls at once:
-         - different colours per direction (gold rows, alternating blue/magenta
-           columns) so the rules read as a pattern, not a uniform mesh;
-         - rule-overlap, which decides who wins where they cross — here the gold
-           rows paint over the columns;
-         - rule-inset-cap vs rule-inset-junction, trimming the outer ends in
-           from the edges while letting the lines cross fully at the junctions. */
     .links ul {
       list-style: none;
       margin: 0;
@@ -349,33 +304,38 @@
         <h3>Consectetur adipiscing</h3>
         <p>Quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
       </article>
+      <article class="post">
+        <span class="date">April 2025</span>
+        <h3>Sed ut perspiciatis</h3>
+        <p>Unde omnis iste natus error sit voluptatem accusantium doloremque laudantium totam rem aperiam.</p>
+      </article>
       <article class="post feature">
         <img class="thumb" src="strings.jpg" alt="Guitar strings in close-up.">
-        <span class="date">April 2025</span>
+        <span class="date">March 2025</span>
         <h3>Ut enim ad minim veniam</h3>
         <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur,
           sunt in culpa qui officia deserunt mollit anim.</p>
       </article>
       <article class="post tall">
-        <img class="thumb" src="tree.jpg" alt="An old olive tree trunk.">
-        <span class="date">March 2025</span>
+        <img class="thumb" src="tram.jpg" alt="Tram tracks running down a street.">
+        <span class="date">February 2025</span>
         <h3>Quis nostrud exercitation</h3>
         <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
           laborum, sed do eiusmod tempor incididunt.</p>
         <p>Ut labore et dolore magna aliqua, quis nostrud.</p>
       </article>
       <article class="post">
-        <span class="date">February 2025</span>
+        <span class="date">January 2025</span>
         <h3>Duis aute irure</h3>
         <p>Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
       </article>
       <article class="post">
-        <span class="date">January 2025</span>
+        <span class="date">December 2024</span>
         <h3>Excepteur sint occaecat</h3>
         <p>Cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </article>
       <article class="post">
-        <span class="date">December 2024</span>
+        <span class="date">November 2024</span>
         <h3>Lorem ipsum dolor sit</h3>
         <p>Amet consectetur adipiscing elit, sed do eiusmod tempor incididunt.</p>
       </article>
@@ -385,7 +345,7 @@
   <section id="about" class="about">
     <h2>About</h2>
     <div class="bio">
-      <img class="avatar" src="cat.jpg" alt="A sleeping cat.">
+      <img class="avatar" src="bike.jpg" alt="A bicycle leaning against a post.">
       <div class="text">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
           dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</p>
@@ -421,5 +381,3 @@
 </body>
 
 </html>
-
-

--- a/css-gap-decorations/personal-site-upgraded.html
+++ b/css-gap-decorations/personal-site-upgraded.html
@@ -225,21 +225,19 @@
 
       display: grid;
       grid-template-columns: repeat(4, 1fr);
-      gap: 2.5rem;
+      gap: 1.5rem 2.5rem;
 
-      row-rule: 4px solid #f5b700;
-      column-rule: 4px solid;
-      column-rule-color: repeat(auto, #4895ef, #f72585);
+      row-rule: 1px solid #c9a96a;
+      column-rule: 3px solid #6a707a;
 
-      rule-overlap: row-over-column;
+      rule-overlap: column-over-row;
 
-      rule-inset-cap: 1rem;
-      rule-inset-junction: 0;
+      column-rule-inset-cap: 1.75rem;
     }
 
     .links li {
-      padding: 0.4rem 0.2rem;
-    }
+      padding: 0.5rem 0.25rem;
+    } 
 
     footer {
       color: #999;

--- a/css-gap-decorations/personal-site-upgraded.html
+++ b/css-gap-decorations/personal-site-upgraded.html
@@ -1,0 +1,398 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS gap decorations — editorial personal site</title>
+  <style>
+    body {
+      font-family: system-ui;
+      font-size: 1.1rem;
+      background: #0d0d0d;
+      color: #efefef;
+      line-height: 1.6;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    h1,
+    h2,
+    h3,
+    p {
+      margin: 0;
+    }
+
+    /* The page itself is one grid. Each section is spaced apart, and the
+       off-white separators between them set the editorial rhythm.
+       repeat(auto, ...) keeps the rules working no matter how many
+       sections the site grows to. */
+    body {
+      display: grid;
+      gap: 4rem;
+      max-width: 1100px;
+      margin: 2rem auto;
+      padding-inline: clamp(1.5rem, 4vw, 3rem);
+      box-sizing: border-box;
+
+      row-rule:
+        1rem solid #efefef,
+        repeat(auto, 2px solid #efefef);
+    }
+
+    header h1 {
+      font-size: 2rem;
+      font-weight: 700;
+    }
+
+    header .tagline {
+      color: #999;
+      font-style: italic;
+      margin-top: 0.25rem;
+    }
+
+    section h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin-bottom: 1.5rem;
+    }
+
+    /* ---- Base content styling --------------------------------------- */
+    /* Like Patrick's starter (which set `article img { width: 100%;
+       max-width: 600px; height: 100%; object-fit: cover }`), we size the
+       masthead photos up front. This is ordinary image hygiene, not a gap
+       decoration: an unstyled <img> reports its natural width as the flex
+       item's min-content size, which would stop flex-basis from shrinking
+       it and blow the layout apart. With this in place, the photos behave
+       like any other block and the gap-decoration steps stay clean. */
+    .portrait {
+      max-width: 280px;
+    }
+
+    .portrait img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    /* ---- Nav: dashed column rules between links ---------------------- */
+    nav ul {
+      font-size: 1.2rem;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+
+      display: flex;
+      flex-wrap: wrap;
+      gap: 2rem;
+      column-rule: 2px dashed #666;
+    }
+
+    /* ---- Home: masthead with varied flex-basis over two lines ------- */
+    /* Echoing the original demo's main grid, the masthead blocks declare
+       DIFFERENT flex-basis values — wide text blocks (420px / 360px) next
+       to narrow image and aside blocks (200px) — so the row wraps into
+       two lines. That makes both decorations earn their place: row-rule
+       draws between the two lines and column-rule between the items in a
+       line. column-rule-inset: 0 keeps the vertical rules spanning each
+       line's content height rather than bleeding into the row gap.
+       (Photo sizing lives in the base content styles above.) */
+    .home {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 3rem;
+
+      row-rule: 2px solid #999;
+      column-rule: 2px solid #999;
+      column-rule-inset: 0;
+    }
+
+    .home > * {
+      flex: 1 1 200px;
+    }
+
+    .home .greeting {
+      flex-basis: 420px;
+    }
+
+    .home .note {
+      flex-basis: 360px;
+    }
+
+    .home .greeting .lead {
+      font-size: 1.35rem;
+      line-height: 1.4;
+    }
+
+    .home .greeting .lead strong {
+      font-weight: 600;
+    }
+
+    .home .now h3 {
+      font-size: 0.8rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #999;
+      margin-bottom: 0.75rem;
+    }
+
+    .home .now ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .home .now li {
+      padding: 0.35rem 0;
+    }
+
+    .home .now li span {
+      color: #999;
+    }
+
+    /* ---- Blog: mixed-span grid of photo + title cards --------------- */
+    .blog .posts {
+      display: grid;
+      /* A fixed three-column grid keeps the spanning/empty-cell behaviour
+         below predictable. (On a real site you'd swap in
+         repeat(auto-fill, minmax(...)) for responsiveness; we pin it to 3
+         here so the demo always lays out the same way.) */
+      grid-template-columns: repeat(3, 1fr);
+      gap: 3rem;
+
+      rule: 2px solid #999;
+
+
+      /* Only paint a separator when BOTH sides of the gap hold a post.
+         The interior hole left when a wide post bumps to the next row,
+         and the ragged last row, stay clean instead of dangling lines
+         into empty space. */
+      rule-visibility-items: between;
+    }
+
+    .post {
+      padding: 0.5rem 0.25rem;
+    }
+
+    .post .thumb {
+      width: 100%;
+      aspect-ratio: 16 / 10;
+      object-fit: cover;
+      margin-bottom: 0.75rem;
+    }
+
+    .post .date {
+      display: block;
+      font-size: 0.85rem;
+      color: #999;
+      margin-bottom: 0.5rem;
+    }
+
+    .post h3 {
+      font-size: 1.2rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .post p {
+      font-size: 0.95rem;
+      color: #cfcfcf;
+    }
+
+    .post.feature {
+      grid-column: span 2;
+    }
+
+    .post.feature .thumb {
+      aspect-ratio: 21 / 9;
+    }
+
+    .post.tall {
+      grid-row: span 2;
+    }
+
+    .post.tall .thumb {
+      /* A portrait crop so the taller card fills its two-row span. */
+      aspect-ratio: 3 / 4;
+    }
+
+    /* ---- About: profile card (avatar | bio) ------------------------- */
+    /* A circular portrait on the left, heading and bio on the right,
+       divided by a single vertical hairline. column-rule-inset pulls the
+       rule in from the top and bottom so it reads as a clean gutter
+       rather than a full-height bar (echoing the home masthead). */
+    .about .bio {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: start;
+      gap: 2.5rem;
+
+      column-rule: 2px solid #999;
+      column-rule-inset: 0.5rem;
+    }
+
+    .about .avatar {
+      flex: 0 0 auto;
+      width: 160px;
+      height: 160px;
+      border-radius: 50%;
+      object-fit: cover;
+    }
+
+    .about .bio .text {
+      flex: 1 1 320px;
+    }
+
+    .about .bio .text p {
+      margin: 0 0 1rem;
+    }
+
+    .about .bio .text p:last-child {
+      margin-bottom: 0;
+    }
+
+    /* ---- Links: inline row with dashed separators ------------------- */
+    /* Plain dashed column rules, reminiscent of the nav at the top. */
+    .links ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+
+      display: flex;
+      flex-wrap: wrap;
+      gap: 2rem;
+
+      column-rule: 2px dashed #666;
+    }
+
+    footer {
+      color: #999;
+      font-size: 0.95rem;
+    }
+  </style>
+</head>
+
+<body>
+  <header>
+    <h1>My personal site</h1>
+    <p class="tagline">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </header>
+
+  <nav>
+    <ul>
+      <li><a href="#home">Home</a></li>
+      <li><a href="#blog">Blog</a></li>
+      <li><a href="#about">About</a></li>
+      <li><a href="#links">Links</a></li>
+    </ul>
+  </nav>
+
+  <section id="home" class="home">
+    <div class="greeting">
+      <p class="lead">Lorem ipsum dolor sit amet, <strong>consectetur adipiscing elit</strong>. Sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    </div>
+    <div class="portrait">
+      <img src="cat.jpg" alt="A sleeping cat.">
+    </div>
+    <aside class="now">
+      <h3>Currently</h3>
+      <ul>
+        <li>Lorem <span>— ipsum dolor sit amet</span></li>
+        <li>Sed <span>— eiusmod tempor incididunt</span></li>
+        <li>Ut enim <span>— ad minim veniam</span></li>
+        <li>Quis <span>— nostrud exercitation</span></li>
+      </ul>
+    </aside>
+    <div class="note">
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.</p>
+    </div>
+    <div class="portrait">
+      <img src="tree.jpg" alt="An old olive tree trunk.">
+    </div>
+  </section>
+
+  <section id="blog" class="blog">
+    <h2>Blog</h2>
+    <div class="posts">
+      <article class="post">
+        <span class="date">June 2025</span>
+        <h3>Lorem ipsum dolor</h3>
+        <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
+      </article>
+      <article class="post">
+        <span class="date">May 2025</span>
+        <h3>Consectetur adipiscing</h3>
+        <p>Quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      </article>
+      <article class="post feature">
+        <img class="thumb" src="strings.jpg" alt="Guitar strings in close-up.">
+        <span class="date">April 2025</span>
+        <h3>Ut enim ad minim veniam</h3>
+        <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur,
+          sunt in culpa qui officia deserunt mollit anim.</p>
+      </article>
+      <article class="post tall">
+        <img class="thumb" src="tree.jpg" alt="An old olive tree trunk.">
+        <span class="date">March 2025</span>
+        <h3>Quis nostrud exercitation</h3>
+        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+          laborum, sed do eiusmod tempor incididunt.</p>
+        <p>Ut labore et dolore magna aliqua, quis nostrud.</p>
+      </article>
+      <article class="post">
+        <span class="date">February 2025</span>
+        <h3>Duis aute irure</h3>
+        <p>Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+      </article>
+      <article class="post">
+        <span class="date">January 2025</span>
+        <h3>Excepteur sint occaecat</h3>
+        <p>Cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </article>
+      <article class="post">
+        <span class="date">December 2024</span>
+        <h3>Lorem ipsum dolor sit</h3>
+        <p>Amet consectetur adipiscing elit, sed do eiusmod tempor incididunt.</p>
+      </article>
+    </div>
+  </section>
+
+  <section id="about" class="about">
+    <h2>About</h2>
+    <div class="bio">
+      <img class="avatar" src="cat.jpg" alt="A sleeping cat.">
+      <div class="text">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
+          dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</p>
+        <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+          Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim.</p>
+        <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam
+          rem aperiam, eaque ipsa quae ab illo inventore veritatis.</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="links" class="links">
+    <h2>Elsewhere</h2>
+    <ul>
+      <li><a href="#">GitHub</a></li>
+      <li><a href="#">Mastodon</a></li>
+      <li><a href="#">RSS</a></li>
+      <li><a href="#">Email</a></li>
+    </ul>
+  </section>
+
+  <footer>
+    <p>&copy; 2025 My personal site.</p>
+  </footer>
+</body>
+
+</html>
+
+


### PR DESCRIPTION
Adds a new demo, personal-site-upgraded.html, to the css-gap-decorations/ directory.

It's an editorial expansion of the existing personal-site.html demo that keeps the same monochrome look and feel while exercising more of the CSS Gap Decorations feature across four sections:

- **Home** — a wrapping flex masthead with varied flex-basis over two lines, using 
ow-rule + column-rule + column-rule-inset.
- **Blog** — a mixed-span grid (wide/tall cards) that stays clean via 
ule-break: intersection and 
ule-visibility-items: between.
- **About** — a profile card with a single inset column-rule gutter.
- **Links** — a dashed column-rule row that echoes the nav.

Reuses the existing cat.jpg / 	ree.jpg / strings.jpg images already in the directory (no new assets). Also adds a README entry under ## Demos.
