### PR TITLE
fix: use form_factor instead of platform in pwamp manifest screenshots

### DIFF
--- a/pwamp/manifest.json
+++ b/pwamp/manifest.json
@@ -40,18 +40,19 @@
     {
       "src": "./screenshot-playlist.png",
       "sizes": "1280x720",
-      "platform": "wide",
+      "form_factor": "wide",
       "label": "The main PWAmp user interface, showing a list of songs, and playback buttons."
     },
     {
       "src": "./screenshot-visualizer.png",
       "sizes": "1280x720",
-      "platform": "wide",
+      "form_factor": "wide",
       "label": "The PWAmp visualizer, showing the current song, the playback buttons, and a colorful visualization of the current song."
     },
     {
       "src": "./screenshot-widget.png",
       "sizes": "600x400",
+      "form_factor": "narrow",
       "label": "The PWAmp mini-player widget"
     }
   ],


### PR DESCRIPTION
Fixes #153

## Problem

The DevTools **Application** panel → **Manifest** page shows the following warning on the [PWAmp demo](https://microsoftedge.github.io/Demos/pwamp/):

> *Richer PWA Install UI won't be available on desktop. Please add at least one screenshot with the `form_factor` set to `wide`.*

## Root Cause

The `screenshots` entries in `pwamp/manifest.json` were using the `platform` property instead of `form_factor`:

```json
{
  "src": "./screenshot-playlist.png",
  "sizes": "1280x720",
  "platform": "wide",
  ...
}
```

The `platform` property is intended for specifying an OS or store target (e.g. `windows`, `android`, `chrome_web_store`). It is not the same as `form_factor`, which is what the browser uses to determine whether to show the richer install UI on desktop.

## Fix

Replaced `platform: wide` with `form_factor: wide` on the two desktop screenshots, and added `form_factor: narrow` to the widget screenshot for completeness, per the [W3C Web App Manifest spec](https://w3c.github.io/manifest/#form_factor-member).