### PR TITLE
[WebInstall] Add manifest URL install demos

### DIFF
--- a/pwa-install-element/README.md
+++ b/pwa-install-element/README.md
@@ -1,6 +1,9 @@
 # Install element demos - `<install>`
 
-This directory contains demos that showcase the use of the [install element](https://aka.ms/InstallElement), a new HTML element under development by the Microsoft Edge team to allow web contents to declaratively install other web apps. The element is currently supported on Windows, MacOS, Linux, and ChromeOS.
+> [!IMPORTANT]
+> Starting in version 153, the manifest-URL design is available. See the [manifest-URL instructions](./manifest-url.md) to learn how to use it. The `installurl` design is expected to be deprecated starting in version 154.
+
+This directory contains demos that showcase the use of the [install element](https://aka.ms/InstallElement), a new HTML element under development to allow web contents to declaratively install other web apps. The element is currently supported on Windows, macOS, Linux, and ChromeOS.
 
 ## Demos
 
@@ -10,7 +13,7 @@ This directory contains demos that showcase the use of the [install element](htt
 
 ### Detect support
 
-```javascrit
+```javascript
 if ('HTMLInstallElement' in window) {
   // The <install> element is supported.
 } else {
@@ -25,9 +28,10 @@ To install the currently loaded document:
 * The document must link to a manifest file.
 * The manifest file must have an `id` field defined.
 
-```javascript
+```html
 <install id="install-button"></install>
 ```
+
 ### Install another document
 
 To install a document that's not the current document, also known as a _background_ document, use either the `installurl` attribute, or both the `installurl` and `manifestid` attributes together:
@@ -37,18 +41,18 @@ To use the `installurl` attribute:
 * The document at `installurl` must link to a manifest file.
 * The manifest file must have an `id` field defined.
 
-```javascript
+```html
 <install installurl="https://foo.com" id="install-button"></install>
 ```
 
 To use the `installurl` and `manifestid` attributes together:
 
-* The document at  `installurl` must link to a manifest file.
-* The value of the `manifestid` attribute must match the computed id after parsing the manifest.
+* The document at `installurl` must link to a manifest file.
+* The value of the `manifestid` attribute must match the computed ID after parsing the manifest.
 
-You can find the computed ID by going to **Application** > **Manifest** > **Identity** > **Computed App ID** in Microsoft Edge DevTools.
+You can find the computed ID by going to **Application** > **Manifest** > **Identity** > **Computed App ID** in DevTools.
 
-```javascript
+```html
 <install installurl="https://foo.com" manifestid="https://foo.com/someid" id="install-button"></install>
 ```
 
@@ -119,4 +123,3 @@ We look forward to hearing from you!
 * [Explainer](https://aka.ms/InstallElement)
 * [Chrome Platform Status Entry](https://chromestatus.com/feature/5152834368700416)
 * [Test experimental APIs and features by using origin trials](https://learn.microsoft.com/microsoft-edge/origin-trials/#using-the-origin-trial-token-at-your-website)
-

--- a/pwa-install-element/manifest-url.md
+++ b/pwa-install-element/manifest-url.md
@@ -1,0 +1,134 @@
+# Install element demos - `<install>`
+
+## Manifest-URL design
+
+This directory contains demos that showcase the use of the [install element](https://github.com/WICG/install-element/blob/main/explainer-manifest-url.md), a new HTML element under development to allow web contents to declaratively install other web apps. The element is currently supported on Windows, macOS, Linux, and ChromeOS.
+
+## Demos
+
+* [The `<install>` Element Store](https://microsoftedge.github.io/Demos/pwa-install-element/)
+* [Web Install Sample](https://kbhlee2121.github.io/pwa/web-install-manifest-url/only-elements.html)
+
+## How to use the `<install>` element
+
+### Detect support
+
+```javascript
+if ('HTMLInstallElement' in window) {
+  // The <install> element is supported.
+} else {
+  // The <install> element is not supported.
+}
+```
+
+### Install the current document
+
+To install the currently loaded document:
+
+* The document must link to a manifest file.
+* The manifest file must have an `id` field defined.
+
+```html
+<install id="install-button"></install>
+```
+
+### Install another document
+
+To install a document that's not the current document, also known as a _background_ document, use either the `manifest` attribute, or both the `manifest` and `manifestId` attributes together:
+
+To use the `manifest` attribute:
+
+* The value of `manifest` must be the URL of the web app manifest to install.
+* The manifest file must have an `id` field defined.
+
+```html
+<install manifest="https://foo.com/manifest.webmanifest" id="install-button"></install>
+```
+
+To use the `manifest` and `manifestId` attributes together:
+
+* The value of `manifest` must be the URL of the web app manifest to install.
+* The value of the `manifestId` attribute must match the computed ID after parsing the manifest.
+
+You can find the computed ID by going to **Application** > **Manifest** > **Identity** > **Computed App ID** in DevTools.
+
+```html
+<install manifest="https://foo.com/manifest.webmanifest" manifestId="https://foo.com/someid" id="install-button"></install>
+```
+
+### Handle installation success and errors
+
+To handle the result of the web app installation process, use the `installresult` event. The event's `result` is `success`, `aborted`, or `invalid_data`:
+
+```javascript
+if ('HTMLInstallElement' in window) {
+  const button = document.getElementById('install-button');
+
+  button.addEventListener('installresult', (event) => {
+    switch (event.result) {
+      case 'success':
+        console.log('Install flow completed successfully');
+        break;
+      case 'aborted':
+        console.log('Install was cancelled or could not be completed');
+        break;
+      case 'invalid_data':
+        console.log('The manifest or manifestId is invalid');
+        break;
+    }
+  });
+} else {
+  console.warn('HTMLInstallElement not supported');
+}
+```
+
+### Use `oninstallresult`
+
+You can also handle the installation result by using the `oninstallresult`
+attribute:
+
+```html
+<install manifest="https://foo.com/manifest.webmanifest"
+         oninstallresult="handleInstallResult(event)"></install>
+
+<script>
+  function handleInstallResult(event) {
+    console.log(`Install result: ${event.result}`);
+  }
+</script>
+```
+
+Or set the corresponding JavaScript property:
+
+```javascript
+const button = document.getElementById('install-button');
+
+button.oninstallresult = (event) => {
+  console.log(`Install result: ${event.result}`);
+};
+```
+
+## Test the feature locally
+
+To test the manifest-URL design locally, in your browser only, use a Chromium-based browser version 153 or later and enable the **Web App Install Element** experiment:
+
+1. In the browser, open a new tab and go to `about://flags/#web-app-install-element`.
+2. Enable the **Web App Install Element** flag.
+3. Click the **Restart** button in the bottom right. The browser restarts.
+
+## Provide feedback
+
+Your feedback is crucial to the development of this feature. Please share feedback to:
+
+* Report any issue you encountered.
+* Share improvement suggestions.
+* Share how you're using the `<install>` element.
+
+To share feedback, [open a new issue on the WICG/install-element repo](https://github.com/WICG/install-element/issues/new?template=install-element-ot-feedback.md)
+
+We look forward to hearing from you!
+
+## See also
+
+* [Manifest-URL design explainer](https://github.com/WICG/install-element/blob/main/explainer-manifest-url.md)
+* [Chrome Platform Status Entry](https://chromestatus.com/feature/5152834368700416)

--- a/pwa-pwastore/README.md
+++ b/pwa-pwastore/README.md
@@ -6,6 +6,8 @@ This is a demo app for a landing page (titled **Edge demos**) that lets you inst
 
 This demo app showcases the manifest-URL design of the Web Install API. This demo app also demonstrates CSS Masonry layout.
 
+The `/pwa-pwastore/` directory is an earlier copy of [/pwa-installer/](https://github.com/MicrosoftEdge/Demos/tree/main/pwa-installer/).  The Web Install API docs point to this earlier, `/pwa-pwastore/` directory, not to the later, `/pwa-installer/` directory.
+
 <!-- ====================================================================== -->
 
 ## Requirements

--- a/pwa-pwastore/README.md
+++ b/pwa-pwastore/README.md
@@ -2,24 +2,22 @@
 
 ➡️ **[Open the demo](https://microsoftedge.github.io/Demos/pwa-pwastore/)** ⬅️
 
-This is a demo app for a landing page (titled **Edge demos** ) that lets you install PWAs from a collection of applications.
+This is a demo app for a landing page (titled **Edge demos**) that lets you install PWAs from a collection of applications.
 
-This demo app showcases the Web Install API.  This demo app also demonstrates CSS Masonry layout.
-
-The `/pwa-pwastore/` directory is an earlier copy of [/pwa-installer/](https://github.com/MicrosoftEdge/Demos/tree/main/pwa-installer/).  The Web Install API Dev Trial docs point to this earlier, `/pwa-pwastore/` directory, not to the later, `/pwa-installer/` directory.
-
+This demo app showcases the manifest-URL design of the Web Install API. This demo app also demonstrates CSS Masonry layout.
 
 <!-- ====================================================================== -->
+
 ## Requirements
 
 This demo application showcases the Web Install API, and also CSS Masonry layout.
 
-* For the demo to work correctly, you must enable a flag for the Web Install API.  That flag is available in browsers based on Chromium, such as Microsoft Edge, starting with version 139.
+* For the demo to work correctly, you must enable a flag for the Web Install API. The manifest-URL design is available in Chromium-based browsers starting with version 153.
 
 * As a progressive enhancement, you can also enable the CSS Masonry flag.
 
-
 <!-- ------------------------------ -->
+
 ### Enable the Web Install API
 
 To enable the Web Install API (required):
@@ -32,10 +30,10 @@ To enable the Web Install API (required):
 
 1. Set the **Web App Installation API** flag to **Enabled**.
 
-1. Click the **Restart** button in the lower right.  The browser restarts.
-
+1. Click the **Restart** button in the lower right. The browser restarts.
 
 <!-- ------------------------------ -->
+
 ### Enable CSS Masonry layout
 
 To enable the CSS Masonry layout flag (a progressive enhancement):
@@ -48,20 +46,24 @@ To enable the CSS Masonry layout flag (a progressive enhancement):
 
 1. Set the **CSS Masonry Layout** flag to **Enabled**.
 
-1. Click the **Restart** button in the lower right.  The browser restarts.
-
+1. Click the **Restart** button in the lower right. The browser restarts.
 
 <!-- ====================================================================== -->
+
 ## See also
 
 Sample description:
+
 * [PWA installer](https://learn.microsoft.com/microsoft-edge/progressive-web-apps/samples/index#pwa-installer) in _Progressive Web App samples_.
 
 Blog post:
+
 * [Microsoft Edge: Web Install API Dev Trial Live](https://www.linkedin.com/feed/update/urn:li:activity:7348768177993998337/)
 
 Explainer:
+
 * [Web Install API](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/WebInstall/explainer.md)
 
 Other live samples:
-* [Web Install Sample](https://kbhlee2121.github.io/pwa/web-install/index.html) - requires the **web-app-installation-api** flag.
+
+* [Web Install Sample](https://kbhlee2121.github.io/pwa/web-install-manifest-url/index.html) - requires the **web-app-installation-api** flag.

--- a/pwa-pwastore/app.js
+++ b/pwa-pwastore/app.js
@@ -10,63 +10,108 @@ const bubbleBtn = document.getElementById('installBubble');
 const appTitleBtn = document.getElementById('installappTitle');
 
 installBtn.addEventListener('click', async () => {
-  await navigator.install();
+  try {
+    const result = await navigator.install();
+    console.log(result);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 pwinterBtn.addEventListener('click', async () => {
-  await navigator.install({
-    manifest: 'https://diek.us/pwinter/manifest.json',
-    manifestId: 'https://diek.us/pwinter/index.html?randomize=true',
-  });
+  try {
+    const result = await navigator.install({
+      manifest: 'https://diek.us/pwinter/manifest.json',
+      manifestId: 'https://diek.us/pwinter/index.html?randomize=true',
+    });
+    console.log(result);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 pwampBtn.addEventListener('click', async () => {
-  await navigator.install({
-    manifest: 'https://microsoftedge.github.io/Demos/pwamp/manifest.json',
-    manifestId: 'https://microsoftedge.github.io/Demos/pwamp/',
-  });
+  try {
+    const result = await navigator.install({
+      manifest: 'https://microsoftedge.github.io/Demos/pwamp/manifest.json',
+      manifestId: 'https://microsoftedge.github.io/Demos/pwamp/',
+    });
+    console.log(result);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 bubbleBtn.addEventListener('click', async () => {
-  await navigator.install({
-    manifest: 'https://diek.us/bubble/manifest.json',
-    manifestId: 'https://diek.us/bubble/',
-  });
+  try {
+    const result = await navigator.install({
+      manifest: 'https://diek.us/bubble/manifest.json',
+      manifestId: 'https://diek.us/bubble/',
+    });
+    console.log(result);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 tempConvBtn.addEventListener('click', async () => {
-  await navigator.install({
-    manifest: 'https://microsoftedge.github.io/Demos/temperature-converter/manifest.json',
-    manifestId: 'https://microsoftedge.github.io/Demos/temperature-converter/',
-  });
+  try {
+    const result = await navigator.install({
+      manifest: 'https://microsoftedge.github.io/Demos/temperature-converter/manifest.json',
+      manifestId: 'https://microsoftedge.github.io/Demos/temperature-converter/',
+    });
+    console.log(result);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 emailClientBtn.addEventListener('click', async () => {
-  await navigator.install({
-    manifest: 'https://microsoftedge.github.io/Demos/email-client/manifest.json',
-    manifestId: 'https://microsoftedge.github.io/Demos/email-client/index.html',
-  });
+  try {
+    const result = await navigator.install({
+      manifest: 'https://microsoftedge.github.io/Demos/email-client/manifest.json',
+      manifestId: 'https://microsoftedge.github.io/Demos/email-client/index.html',
+    });
+    console.log(result);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 oneDivBtn.addEventListener('click', async () => {
-  await navigator.install({
-    manifest: 'https://microsoftedge.github.io/Demos/1DIV/dist/manifest.json',
-    manifestId: 'https://microsoftedge.github.io/Demos/1DIV/dist/index.html',
-  });
+  try {
+    const result = await navigator.install({
+      manifest: 'https://microsoftedge.github.io/Demos/1DIV/dist/manifest.json',
+      manifestId: 'https://microsoftedge.github.io/Demos/1DIV/dist/index.html',
+    });
+    console.log(result);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 wamiBtn.addEventListener('click', async () => {
-  await navigator.install({
-    manifest: 'https://microsoftedge.github.io/Demos/wami/manifest.json',
-    manifestId: 'https://microsoftedge.github.io/Demos/wami/',
-  });
+  try {
+    const result = await navigator.install({
+      manifest: 'https://microsoftedge.github.io/Demos/wami/manifest.json',
+      manifestId: 'https://microsoftedge.github.io/Demos/wami/',
+    });
+    console.log(result);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 appTitleBtn.addEventListener('click', async () => {
-  await navigator.install({
-    manifest: 'https://microsoftedge.github.io/Demos/pwa-application-title/manifest.json',
-    manifestId: 'https://microsoftedge.github.io/Demos/pwa-application-title/',
-  });
+  try {
+    const result = await navigator.install({
+      manifest: 'https://microsoftedge.github.io/Demos/pwa-application-title/manifest.json',
+      manifestId: 'https://microsoftedge.github.io/Demos/pwa-application-title/',
+    });
+    console.log(result);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 const init = () => {

--- a/pwa-pwastore/app.js
+++ b/pwa-pwastore/app.js
@@ -1,60 +1,79 @@
 // All of the UI DOM elements we need.
-const installBtn = document.getElementById("btnInstallStore");
-const pwinterBtn = document.getElementById("installPwinter");
-const pwampBtn = document.getElementById("installPwamp");
-const tempConvBtn = document.getElementById("installPwaGettingStarted");
-const emailClientBtn = document.getElementById("installEmailClient");
-const oneDivBtn = document.getElementById("install1Div");
-const wamiBtn = document.getElementById("installWami");
-const bubbleBtn = document.getElementById("installBubble");
-const appTitleBtn = document.getElementById("installappTitle");
-
+const installBtn = document.getElementById('btnInstallStore');
+const pwinterBtn = document.getElementById('installPwinter');
+const pwampBtn = document.getElementById('installPwamp');
+const tempConvBtn = document.getElementById('installPwaGettingStarted');
+const emailClientBtn = document.getElementById('installEmailClient');
+const oneDivBtn = document.getElementById('install1Div');
+const wamiBtn = document.getElementById('installWami');
+const bubbleBtn = document.getElementById('installBubble');
+const appTitleBtn = document.getElementById('installappTitle');
 
 installBtn.addEventListener('click', async () => {
-  let installation = await navigator.install();
+  await navigator.install();
 });
 
 pwinterBtn.addEventListener('click', async () => {
-  let installation = await navigator.install('https://diek.us/pwinter/',
-                    'https://diek.us/pwinter/index.html?randomize=true');
+  await navigator.install({
+    manifest: 'https://diek.us/pwinter/manifest.json',
+    manifestId: 'https://diek.us/pwinter/index.html?randomize=true',
+  });
 });
 
 pwampBtn.addEventListener('click', async () => {
-  let installation = await navigator.install('https://microsoftedge.github.io/Demos/pwamp/',
-                    'https://microsoftedge.github.io/Demos/pwamp/');
+  await navigator.install({
+    manifest: 'https://microsoftedge.github.io/Demos/pwamp/manifest.json',
+    manifestId: 'https://microsoftedge.github.io/Demos/pwamp/',
+  });
 });
 
 bubbleBtn.addEventListener('click', async () => {
-  let installation = await navigator.install('https://diek.us/bubble/',
-                    'https://diek.us/bubble/index.html');
+  await navigator.install({
+    manifest: 'https://diek.us/bubble/manifest.json',
+    manifestId: 'https://diek.us/bubble/',
+  });
 });
 
 tempConvBtn.addEventListener('click', async () => {
-  let installation = await navigator.install('https://microsoftedge.github.io/Demos/temperature-converter/index.html', 'https://microsoftedge.github.io/Demos/temperature-converter/');
-
+  await navigator.install({
+    manifest: 'https://microsoftedge.github.io/Demos/temperature-converter/manifest.json',
+    manifestId: 'https://microsoftedge.github.io/Demos/temperature-converter/',
+  });
 });
 
 emailClientBtn.addEventListener('click', async () => {
-  let installation = await navigator.install('https://microsoftedge.github.io/Demos/email-client/',
-                    'https://microsoftedge.github.io/Demos/email-client/index.html');
+  await navigator.install({
+    manifest: 'https://microsoftedge.github.io/Demos/email-client/manifest.json',
+    manifestId: 'https://microsoftedge.github.io/Demos/email-client/index.html',
+  });
 });
 
 oneDivBtn.addEventListener('click', async () => {
-  let installation = await navigator.install('https://microsoftedge.github.io/Demos/1DIV/dist/',
-                    'https://microsoftedge.github.io/Demos/1DIV/dist/index.html');
-}); 
+  await navigator.install({
+    manifest: 'https://microsoftedge.github.io/Demos/1DIV/dist/manifest.json',
+    manifestId: 'https://microsoftedge.github.io/Demos/1DIV/dist/index.html',
+  });
+});
 
 wamiBtn.addEventListener('click', async () => {
-  let installation = await navigator.install('https://microsoftedge.github.io/Demos/wami/index.html', 'https://microsoftedge.github.io/Demos/wami/');
-}); 
+  await navigator.install({
+    manifest: 'https://microsoftedge.github.io/Demos/wami/manifest.json',
+    manifestId: 'https://microsoftedge.github.io/Demos/wami/',
+  });
+});
 
 appTitleBtn.addEventListener('click', async () => {
-  let installation = await navigator.install('https://microsoftedge.github.io/Demos/pwa-application-title/', 'https://microsoftedge.github.io/Demos/pwa-application-title/');
-}); 
-
+  await navigator.install({
+    manifest: 'https://microsoftedge.github.io/Demos/pwa-application-title/manifest.json',
+    manifestId: 'https://microsoftedge.github.io/Demos/pwa-application-title/',
+  });
+});
 
 const init = () => {
-  if (window.matchMedia('(display-mode: standalone)').matches || window.matchMedia('(display-mode: window-controls-overlay)').matches) {
+  const isInstalled = window.matchMedia('(display-mode: standalone)').matches ||
+    window.matchMedia('(display-mode: window-controls-overlay)').matches;
+
+  if (isInstalled) {
     installBtn.style.display = 'none';
   }
 };

--- a/pwa-pwastore/index.html
+++ b/pwa-pwastore/index.html
@@ -33,7 +33,7 @@
             <p>This collection contains demo webpages, apps, and sample code to demonstrate various features of Microsoft Edge. You can filter the type of demo with the buttons above.</p>
             <p><strong>Some additional details for demos to work:</strong></p>
             <ul>
-                <li>Check if you need to enable any experimental features in <code>about://flags</code>.</li>
+                <li>Check if you need to enable the feature flag at <code>about://flags/#web-app-installation-api</code>.</li>
                 <li><a href="https://developer.microsoft.com/microsoft-edge/origin-trials/trials" target="_blank">List of active Origin Trials on Microsoft Edge.</a></li>
                 <li>This app uses the <a href="https://aka.ms/webinstall">Web Install API</a> to install demos and the <a href="https://developer.chrome.com/blog/masonry" target="_blank">Masonry layout</a> to arrange items.</li>
             </ul>

--- a/pwa-web-install-api/README.md
+++ b/pwa-web-install-api/README.md
@@ -1,87 +1,98 @@
-# web install API - `navigator.install`
+# Web Install API - `navigator.install()`
 
-This directory contains demos that showcase the use of [navigator.install](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/WebInstall/explainer.md), an API under development by the Microsoft Edge team to allow web contents to declaratively install other web apps.
+> [!IMPORTANT]
+> Starting in version 153, the manifest-URL design is available. See the [manifest-URL instructions](./manifest-url.md) to learn how to use it. The `install_url` design is expected to be deprecated starting in version 154.
+
+This directory contains demos that showcase the use of [navigator.install](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/WebInstall/explainer.md), an API under development to allow web contents to install other web apps.
 
 ## Demos
 
-* [PWA Installer](https://microsoftedge.github.io/Demos/pwa-pwastore)
 * [Web Install Sample](https://kbhlee2121.github.io/pwa/web-install/index.html)
 
-## How to Use It
+## How to use it
 
-### Install the current loaded document
+### Install the currently loaded document
 
-**`install()`Requirements**: 
+**`install()` requirements:**
+
 * The current document must link to a manifest file.
 * The manifest file must have an `id` field defined.
 
 ```javascript
-/* Current Document: 0-param Signature*/
+/* Current document: no-argument signature. */
 const installApp = async () => {
-    if (!navigator.install) return; // api not supported
-    try {
-        await navigator.install();
-    } catch(err) {
-        switch(err.name){
-            case 'AbortError':
-                /* Operation was aborted*/
-                break;
-        }
+  if (!navigator.install) return; // API not supported.
+
+  try {
+    await navigator.install();
+  } catch (err) {
+    switch (err.name) {
+      case 'AbortError':
+        /* Operation was aborted. */
+        break;
     }
+  }
 };
 ```
+
 ### Install a background document (any app that's not the current document)
 
-**`install(<install_url>)` Requirements:**
-* The document at  `install_url` must link to a manifest file.
+**`install(<install_url>)` requirements:**
+
+* The document at `install_url` must link to a manifest file.
 * The manifest file must have an `id` field defined.
 
 ```javascript
-/*Background Document: 1-param Signature*/
+/* Background document: one-argument signature. */
 const installApp = async (install_url) => {
-    if (!navigator.install) return; // api not supported
-    try {
-        await navigator.install(install_url);
-    } catch(err) {
-        switch(err.name){
-            case 'AbortError':
-                /* Operation was aborted*/
-                break;
-            case 'DataError':
-                /*issue with manifest file or id*/
-                break;
-        }
+  if (!navigator.install) return; // API not supported.
+
+  try {
+    await navigator.install(install_url);
+  } catch (err) {
+    switch (err.name) {
+      case 'AbortError':
+        /* Operation was aborted. */
+        break;
+      case 'DataError':
+        /* There is an issue with the manifest file or ID. */
+        break;
     }
+  }
 };
 ```
-**`install(<install_url>, <manifest_id>)` Requirements:**
-* The document at  `install_url` must link to a manifest file.
-* `manifest_id` must match the computed id after parsing the manifest.
+
+**`install(<install_url>, <manifest_id>)` requirements:**
+
+* The document at `install_url` must link to a manifest file.
+* `manifest_id` must match the computed ID after parsing the manifest.
 
 ```javascript
-/*Background Document: 2-param Signature*/
+/* Background document: two-argument signature. */
 const installApp = async (install_url, manifest_id) => {
-    if (!navigator.install) return; // api not supported
-    try {
-        await navigator.install(install_url, manifest_id);
-    } catch(err) {
-        switch(err.name){
-            case 'AbortError':
-                /* Operation was aborted*/
-                break;
-            case 'DataError':
-                /*issue with manifest file or id*/
-                break;
-        }
+  if (!navigator.install) return; // API not supported.
+
+  try {
+    await navigator.install(install_url, manifest_id);
+  } catch (err) {
+    switch (err.name) {
+      case 'AbortError':
+        /* Operation was aborted. */
+        break;
+      case 'DataError':
+        /* There is an issue with the manifest file or ID. */
+        break;
     }
+  }
 };
 ```
 
-## Try it with Origin Trials!
+## Try it with origin trials
 
 The Web Install API is currently available as an [Origin Trial](https://developer.chrome.com/docs/web-platform/origin-trials/) in Chrome and Microsoft Edge versions 143-148. This allows you to use the feature on your production site and provide valuable feedback to browser vendors before it's finalized.
 
 To participate, you'll need to:
+
 1. **Register for the Origin Trial:** [Web Install registration page link](https://developer.chrome.com/origintrials/#/view_trial/2367204554136616961)
 2. **Add the Origin Trial Token:** Once you have your token, add it to your pages via a `<meta>` tag or an HTTP header.
 
@@ -89,9 +100,10 @@ To participate, you'll need to:
 <!-- Example of adding the token via a meta tag -->
 <meta http-equiv="origin-trial" content="YOUR_TOKEN_HERE">
 ```
+
 **The token obtained in step 1 will enable the trial for both Chrome and Edge.** See [Origin Trials Guide for Web Developers](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md) to learn more about Origin Trials.
 
-## Provide Feedback
+## Provide feedback
 
 Your feedback is crucial to the development of this feature. If you encounter any issues, have suggestions, or want to share how you're using the Web Install API, please:
 
@@ -99,7 +111,8 @@ Your feedback is crucial to the development of this feature. If you encounter an
 
 We look forward to hearing from you!
 
-## Further Reading and References
+## Further reading and references
+
 * [Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/WebInstall/explainer.md)
 * [Chrome Platform Status Entry](https://chromestatus.com/feature/5183481574850560)
 * [Origin Trials Guide for Web Developers](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md)

--- a/pwa-web-install-api/manifest-url.md
+++ b/pwa-web-install-api/manifest-url.md
@@ -101,7 +101,7 @@ The promise returned by `navigator.install()` resolves when the install flow com
 * `DataError`: The manifest couldn't be fetched or parsed, or its ID is missing or doesn't match `manifestId`.
 * `InvalidStateError`: The call was made from a sandboxed frame or cross-origin subframe.
 * `NotAllowedError`: The call lacked transient user activation or was disallowed by browser policy.
-* `NotFoundError`: The required document is missing.
+* `NotFoundError`: The `Navigator` is no longer attached to a document.
 * `TypeError`: An argument has an invalid type or URL.
 
 ```javascript

--- a/pwa-web-install-api/manifest-url.md
+++ b/pwa-web-install-api/manifest-url.md
@@ -101,6 +101,7 @@ The promise returned by `navigator.install()` resolves when the install flow com
 * `DataError`: The manifest couldn't be fetched or parsed, or its ID is missing or doesn't match `manifestId`.
 * `InvalidStateError`: The call was made from a sandboxed frame or cross-origin subframe.
 * `NotAllowedError`: The call lacked transient user activation or was disallowed by browser policy.
+* `NotFoundError`: The required document is missing.
 * `TypeError`: An argument has an invalid type or URL.
 
 ```javascript
@@ -123,6 +124,7 @@ button.addEventListener('click', async () => {
         break;
       case 'InvalidStateError':
       case 'NotAllowedError':
+      case 'NotFoundError':
       case 'TypeError':
         console.error(`Install flow failed: ${err.name}`);
         break;

--- a/pwa-web-install-api/manifest-url.md
+++ b/pwa-web-install-api/manifest-url.md
@@ -1,0 +1,159 @@
+# Web Install API - `navigator.install()`
+
+## Manifest-URL design
+
+This directory contains demos that showcase the use of [navigator.install](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/WebInstall/explainer.md), an API under development to allow web contents to install other web apps.
+
+## Demos
+
+* [PWA Installer](https://microsoftedge.github.io/Demos/pwa-pwastore)
+* [Web Install Sample](https://kbhlee2121.github.io/pwa/web-install-manifest-url/index.html)
+
+## How to use it
+
+### Detect support
+
+```javascript
+if ('install' in navigator) {
+  // navigator.install is supported.
+} else {
+  // navigator.install is not supported.
+}
+```
+
+### Install the currently loaded document
+
+**`install()` requirements:**
+
+* The current document must link to a manifest file.
+* The manifest file must have an `id` field defined.
+
+```javascript
+const installApp = async () => {
+  if (!navigator.install) return; // API not supported.
+
+  try {
+    await navigator.install();
+    console.log('Install flow completed successfully');
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      console.log('Install was cancelled or could not be completed');
+    }
+  }
+};
+```
+
+### Install a background document
+
+To install a document that's not the current document, use an options object with either `manifest`, or both `manifest` and `manifestId`.
+
+**`install({ manifest })` requirements:**
+
+* `manifest` must be the URL of the web app manifest to install.
+* The manifest file must have an `id` field defined.
+
+```javascript
+const installApp = async (manifest) => {
+  if (!navigator.install) return; // API not supported.
+
+  try {
+    await navigator.install({ manifest });
+    console.log('Install flow completed successfully');
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      console.log('Install was cancelled or could not be completed');
+    } else if (err.name === 'DataError') {
+      console.log('The manifest or manifestId is invalid');
+    }
+  }
+};
+```
+
+**`install({ manifest, manifestId })` requirements:**
+
+* `manifest` must be the URL of the web app manifest to install.
+* `manifestId` must match the computed ID after parsing the manifest.
+
+You can find the computed ID by going to **Application** > **Manifest** > **Identity** > **Computed App ID** in DevTools.
+
+```javascript
+const installApp = async (manifest, manifestId) => {
+  if (!navigator.install) return; // API not supported.
+
+  try {
+    await navigator.install({ manifest, manifestId });
+    console.log('Install flow completed successfully');
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      console.log('Install was cancelled or could not be completed');
+    } else if (err.name === 'DataError') {
+      console.log('The manifest or manifestId is invalid');
+    }
+  }
+};
+```
+
+### Handle installation errors
+
+The promise returned by `navigator.install()` resolves when the install flow completes successfully. It rejects with a `DOMException` when the flow doesn't complete:
+
+* `AbortError`: The user exited the installation flow.
+* `DataError`: The manifest couldn't be fetched or parsed, or its ID is missing or doesn't match `manifestId`.
+* `InvalidStateError`: The call was made from a sandboxed frame or cross-origin subframe.
+* `NotAllowedError`: The call lacked transient user activation or was disallowed by browser policy.
+* `TypeError`: An argument has an invalid type or URL.
+
+```javascript
+const button = document.querySelector('#install');
+
+button.addEventListener('click', async () => {
+  try {
+    await navigator.install({
+      manifest: 'https://foo.com/manifest.json',
+      manifestId: 'https://foo.com/home',
+    });
+    console.log('Install flow completed successfully');
+  } catch (err) {
+    switch (err.name) {
+      case 'AbortError':
+        console.log('Install was cancelled or could not be completed');
+        break;
+      case 'DataError':
+        console.log('The manifest or manifestId is invalid');
+        break;
+      case 'InvalidStateError':
+      case 'NotAllowedError':
+      case 'TypeError':
+        console.error(`Install flow failed: ${err.name}`);
+        break;
+      default:
+        console.error('Install flow failed unexpectedly', err);
+    }
+  }
+});
+```
+
+## Test the feature locally
+
+To test the manifest-URL design locally, in your browser only, use a Chromium-based browser version 153 or later and enable the **Web App Installation API** experiment:
+
+1. In the browser, open a new tab and go to `about://flags/#web-app-installation-api`.
+2. Enable the **Web App Installation API** flag.
+3. Click the **Restart** button in the bottom right. The browser restarts.
+
+## Provide feedback
+
+Your feedback is crucial to the development of this feature. Please share feedback to:
+
+* Report any issue you encountered.
+* Share improvement suggestions.
+* Share how you're using the Web Install API.
+
+To share feedback, [open a new issue on the MSEdgeExplainers repo](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?template=web-install-api.md).
+
+We look forward to hearing from you!
+
+## See also
+
+* [Manifest-URL design explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/WebInstall/explainer.md)
+* [Chrome Platform Status Entry](https://chromestatus.com/feature/5183481574850560)

--- a/pwa-web-install-api/manifest-url.md
+++ b/pwa-web-install-api/manifest-url.md
@@ -6,7 +6,7 @@ This directory contains demos that showcase the use of [navigator.install](https
 
 ## Demos
 
-* [PWA Installer](https://microsoftedge.github.io/Demos/pwa-pwastore)
+* [PWA Store](https://microsoftedge.github.io/Demos/pwa-pwastore)
 * [Web Install Sample](https://kbhlee2121.github.io/pwa/web-install-manifest-url/index.html)
 
 ## How to use it


### PR DESCRIPTION
## Summary

- add Manifest-URL design guides for the install element and Web Install API
- add migration notices to the legacy install URL documentation
- migrate the PWA Store demo to the manifest-based Web Install API
- update sample links, result handling, and browser-version guidance

Follow-up: Remove all context in both legacy install URL Demos except the redirect links to the new manifest-url **after** the install_url attribute has been deprecated and removed from code.