### PR TITLE
Add 'play', 'pause', 'seeked', 'ended' media events & guard

### DIFF
--- a/pwamp/media-session.js
+++ b/pwamp/media-session.js
@@ -7,11 +7,13 @@ export function initMediaSession(player) {
 
   function updateMediaSessionState() {
     navigator.mediaSession.playbackState = player.audio.paused ? 'paused' : 'playing';
-    navigator.mediaSession.setPositionState({
-      duration: player.audio.duration,
-      position: player.audio.currentTime,
-      playbackRate: player.audio.playbackRate
-    });
+    if (player.audio.duration && !isNaN(player.audio.duration) && isFinite(player.audio.duration)) {
+      navigator.mediaSession.setPositionState({
+        duration: player.audio.duration,
+        position: player.audio.currentTime,
+        playbackRate: player.audio.playbackRate
+      });
+    }
   }
 
   async function updateMediaSessionMetadata() {
@@ -48,7 +50,7 @@ export function initMediaSession(player) {
     }
   }
 
-  const audioEvents = ['playing', 'paused', 'durationchange', 'ratechange', 'timechange'];
+  const audioEvents = ['playing', 'paused', 'durationchange', 'ratechange', 'timechange', 'play', 'pause', 'seeked', 'ended'];
   for (const event of audioEvents) {
     player.audio.addEventListener(event, updateMediaSessionState);
   }


### PR DESCRIPTION
'Play' and 'pause' (not 'playing', 'paused') are the standard names for HTMLMediaEvents: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play_event

Also add:
- 'Seeked' and 'ended' events.
- A guard that ensures audio.duration is a valid finite number before calling setPositionState(). This prevents crashing if playback events fire before metadata loads.

This fixes inconsistencies that were observed with system media indicators on Android.